### PR TITLE
Add Missing Headless Artifact Change Tests to CI

### DIFF
--- a/libbs/api/artifact_dict.py
+++ b/libbs/api/artifact_dict.py
@@ -41,7 +41,7 @@ class ArtifactDict(dict):
             # ArtifactType: (setter, getter, lister)
             Function: (self._deci._set_function, self._deci._get_function, self._deci._functions),
             StackVariable: (self._deci._set_stack_variable, self._deci._get_stack_variable, self._deci._stack_variables),
-            GlobalVariable: (self._deci._set_global_variable, self._deci._get_global_var, self._deci._global_vars),
+            GlobalVariable: (self._deci._set_global_var, self._deci._get_global_var, self._deci._global_vars),
             Struct: (self._deci._set_struct, self._deci._get_struct, self._deci._structs),
             Enum: (self._deci._set_enum, self._deci._get_enum, self._deci._enums),
             Comment: (self._deci._set_comment, self._deci._get_comment, self._deci._comments),

--- a/libbs/api/artifact_dict.py
+++ b/libbs/api/artifact_dict.py
@@ -41,7 +41,7 @@ class ArtifactDict(dict):
             # ArtifactType: (setter, getter, lister)
             Function: (self._deci._set_function, self._deci._get_function, self._deci._functions),
             StackVariable: (self._deci._set_stack_variable, self._deci._get_stack_variable, self._deci._stack_variables),
-            GlobalVariable: (self._deci._set_global_var, self._deci._get_global_var, self._deci._global_vars),
+            GlobalVariable: (self._deci._set_global_variable, self._deci._get_global_var, self._deci._global_vars),
             Struct: (self._deci._set_struct, self._deci._get_struct, self._deci._structs),
             Enum: (self._deci._set_enum, self._deci._get_enum, self._deci._enums),
             Comment: (self._deci._set_comment, self._deci._get_comment, self._deci._comments),

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -505,7 +505,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
                 name.count('/') == 1} if names else {}
 
     @ghidra_transaction
-    def fill_global_var(self, var_addr, user=None, artifact=None, **kwargs):
+    def _set_global_var(self, var_addr, user=None, artifact=None, **kwargs):
         """
         TODO: remove me and implement me properly as setters and getters
         """

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -505,7 +505,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
                 name.count('/') == 1} if names else {}
 
     @ghidra_transaction
-    def _set_global_var(self, var_addr, user=None, artifact=None, **kwargs):
+    def _set_global_variable(self, var_addr, user=None, artifact=None, **kwargs):
         """
         TODO: remove me and implement me properly as setters and getters
         """

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -68,6 +68,18 @@ class TestHeadlessInterfaces(unittest.TestCase):
         deci.enums[enum.name] = enum
         assert deci.enums[enum.name] == enum
 
+        # gvar_addr = deci.art_lifter.lift_addr(0x4008e0)
+        # g1 = deci.global_vars[gvar_addr]
+        # g1.name = "gvar1"
+        # deci.global_vars[gvar_addr] = g1
+        # assert deci.global_vars[gvar_addr] == g1
+
+        stack_var = main.stack_vars[-24]
+        stack_var.name = "named_char_array"
+        stack_var.type = 'double'
+        deci.functions[func_addr] = main
+        assert deci.functions[func_addr].stack_vars[-24] == stack_var
+
         #
         # Test Artifact Watchers
         #

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -23,6 +23,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         self._fauxware_path = TEST_BINARY_DIR / "fauxware"
 
     def test_ghidra(self):
+        # TODO: Add test cases for structs and enums
         # useful command for testing, kills all Headless-Ghidra:
         # kill $(ps aux | grep 'Ghidra-Headless' | awk '{print $2}')
         deci = DecompilerInterface.discover(

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -54,6 +54,20 @@ class TestHeadlessInterfaces(unittest.TestCase):
         deci.functions[func_addr] = main
         assert deci.functions[func_addr].header.args == func_args
 
+        struct = deci.structs['/eh_frame_hdr']
+        struct.name = "my_struct_name"
+        struct.members[0].type = 'undefined'
+        struct.members[1].type = 'undefined'
+        deci.structs['/eh_frame_hdr'] = struct
+        updated = deci.structs['/' + struct.name]
+        assert updated.name == struct.name
+        assert updated.members[0].type == 'undefined'
+        assert updated.members[1].type == 'undefined'
+
+        enum = Enum("my_enum", {"member1": 0, "member2": 1})
+        deci.enums[enum.name] = enum
+        assert deci.enums[enum.name] == enum
+
         #
         # Test Artifact Watchers
         #


### PR DESCRIPTION
Currently needs tests for ~~Struct Edits, Enum Edits~~, ~~Stack Vars~~, and Global Vars 