### PR TITLE
Rework how structs are keyed

### DIFF
--- a/libbs/decompilers/ghidra/hooks.py
+++ b/libbs/decompilers/ghidra/hooks.py
@@ -54,7 +54,7 @@ def create_data_monitor(ghidra: "GhidraAPIWrapper", interface: "GhidraDecompiler
                     pass
                 elif changeType in typeEvents:
                     try:
-                        struct = self._interface.structs['/'+newValue.name]
+                        struct = self._interface.structs[newValue.name]
                         # TODO: access old name indicate deletion
                         #self._interface.struct_changed(Struct(None, None, None), deleted=True)
                         self._interface.struct_changed(struct)
@@ -62,7 +62,7 @@ def create_data_monitor(ghidra: "GhidraAPIWrapper", interface: "GhidraDecompiler
                         pass
 
                     try:
-                        enum = self._interface.enums['/'+newValue.name]
+                        enum = self._interface.enums[newValue.name]
                         #self._interface.enum_changed(Enum(None, None), deleted=True)
                         self._interface.enum_changed(enum)
                     except KeyError:

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -390,7 +390,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
     @ghidra_transaction
     def _set_struct(self, struct: Struct, header=True, members=True, **kwargs) -> bool:
         struct: Struct = struct
-        old_ghidra_struct = self._get_struct_by_name('/' + struct.name)
+        old_ghidra_struct = self._get_struct_by_name(struct.name)
         data_manager = self.ghidra.currentProgram.getDataTypeManager()
         handler = self.ghidra.import_module_object("ghidra.program.model.data", "DataTypeConflictHandler")
         structType = self.ghidra.import_module_object("ghidra.program.model.data", "StructureDataType")
@@ -428,7 +428,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
             "for s in currentProgram.getDataTypeManager().getAllStructures()]"
         )
         return {
-            name: Struct(name, size, members=self._struct_members_from_gstruct(name)) for name, size in name_sizes
+            name[1:]: Struct(name[1:], size, members=self._struct_members_from_gstruct(name[1:])) for name, size in name_sizes
         } if name_sizes else {}
 
     @ghidra_transaction
@@ -637,7 +637,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
         )
 
     def _get_struct_by_name(self, name: str) -> "GhidraStructure":
-        return self.ghidra.currentProgram.getDataTypeManager().getDataType(name)
+        return self.ghidra.currentProgram.getDataTypeManager().getDataType('/' + name)
 
     def _struct_members_from_gstruct(self, name: str) -> Dict[int, StructMember]:
         ghidra_struct = self._get_struct_by_name(name)

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -110,9 +110,9 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # main.stack_vars[-12].name = "named_int"
         # deci.functions[func_addr] = main
 
-        # struct = deci.structs['/eh_frame_hdr']
+        # struct = deci.structs['eh_frame_hdr']
         # struct.name = "my_struct_name"
-        # deci.structs['/eh_frame_hdr'] = struct
+        # deci.structs['eh_frame_hdr'] = struct
 
         # TODO: add argument naming
         # func_args = main.header.args

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -54,12 +54,12 @@ class TestHeadlessInterfaces(unittest.TestCase):
         deci.functions[func_addr] = main
         assert deci.functions[func_addr].header.args == func_args
 
-        struct = deci.structs['/eh_frame_hdr']
+        struct = deci.structs['eh_frame_hdr']
         struct.name = "my_struct_name"
         struct.members[0].type = 'undefined'
         struct.members[1].type = 'undefined'
-        deci.structs['/eh_frame_hdr'] = struct
-        updated = deci.structs['/' + struct.name]
+        deci.structs['eh_frame_hdr'] = struct
+        updated = deci.structs[struct.name]
         assert updated.name == struct.name
         assert updated.members[0].type == 'undefined'
         assert updated.members[1].type == 'undefined'


### PR DESCRIPTION
Fixes how structs are stored to be consistent with enums. The key for a struct no longer includes the leading "/" and the slash placement is handled internally by `get_struct_by_name`.