### PR TITLE
Support for Artifact formatting (JSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,15 @@ for func_addr, light_func in deci.functions.items():
 
 Notice, when using the `items` function the function is `light`, meaning it does not contain stack vars and other 
 info. This also means using `keys`, `values`, or `list` on an artifact dictionary will have the same affect. 
+
+### Serializing Artifacts
+All artifacts are serializable to the TOML and JSON formats. Serialization is done like so:
+```python
+from libbs.artifacts import Function
+import json
+
+my_func = Function(name="my_func", addr=0x4000, size=0x10)
+json_str = my_func.dumps(fmt="json")
+loaded_dict = json.loads(json_str) # now loadable through normal JSON parsing
+print(json_str)
+```

--- a/libbs/__init__.py
+++ b/libbs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.5.2"
+__version__ = "1.6.0"
 
 import logging
 logging.getLogger("libbs").addHandler(logging.NullHandler())

--- a/libbs/artifacts/__init__.py
+++ b/libbs/artifacts/__init__.py
@@ -1,4 +1,4 @@
-from .formatting import TomlHexEncoder
+from .formatting import TomlHexEncoder, ArtifactFormat
 from .artifact import Artifact
 from .comment import Comment
 from .decompilation import Decompilation

--- a/libbs/artifacts/__init__.py
+++ b/libbs/artifacts/__init__.py
@@ -1,4 +1,5 @@
-from .artifact import Artifact, TomlHexEncoder
+from .formatting import TomlHexEncoder
+from .artifact import Artifact
 from .comment import Comment
 from .decompilation import Decompilation
 from .enum import Enum

--- a/libbs/artifacts/artifact.py
+++ b/libbs/artifacts/artifact.py
@@ -28,7 +28,8 @@ class Artifact:
 
     def __setstate__(self, state):
         for k in self.__slots__:
-            setattr(self, k, state.get(k, None))
+            if k in state:
+                setattr(self, k, state[k])
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/libbs/artifacts/comment.py
+++ b/libbs/artifacts/comment.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import toml
 
 from .artifact import Artifact
@@ -9,22 +11,24 @@ class Comment(Artifact):
         "func_addr",
         "comment",
         "decompiled",
-
     )
 
-    def __init__(self, addr, comment,  func_addr=None, decompiled=False, last_change=None):
-        super(Comment, self).__init__(last_change=last_change)
-
-        self.comment = self.linewrap_comment(comment) if comment else ""
-        self.decompiled = decompiled
-        self.addr = addr  # type: int
+    def __init__(
+        self,
+        addr: int = None,
+        comment: Optional[str] = None,
+        func_addr: int = None,
+        decompiled: bool = False,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.addr = addr
+        self.comment = self.linewrap_comment(comment) if comment else None
         self.func_addr = func_addr
+        self.decompiled = decompiled
 
     def __str__(self):
         return f"<Comment: @{hex(self.addr)} len={len(self.comment)}>"
-
-    def __repr__(self):
-        return self.__str__()
 
     @staticmethod
     def linewrap_comment(comment: str, width=80):
@@ -44,12 +48,6 @@ class Comment(Artifact):
             final_comment += "\n"
 
         return final_comment
-
-    @classmethod
-    def parse(cls, s):
-        comm = Comment(None, None)
-        comm.__setstate__(toml.loads(s))
-        return comm
 
     @classmethod
     def load_many(cls, comms_toml):
@@ -72,8 +70,8 @@ class Comment(Artifact):
 
     def copy(self):
         return Comment(
-            self.addr,
-            self.comment,
+            addr=self.addr,
+            comment=self.comment,
             func_addr=self.func_addr,
             decompiled=self.decompiled,
             last_change=self.last_change

--- a/libbs/artifacts/comment.py
+++ b/libbs/artifacts/comment.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-import toml
-
 from .artifact import Artifact
 
 
@@ -48,34 +46,6 @@ class Comment(Artifact):
             final_comment += "\n"
 
         return final_comment
-
-    @classmethod
-    def load_many(cls, comms_toml):
-        for comm_toml in comms_toml.values():
-            comm = Comment(None, None)
-            try:
-                comm.__setstate__(comm_toml)
-            except TypeError:
-                # skip all incorrect ones
-                continue
-            yield comm
-
-    @classmethod
-    def dump_many(cls, comments):
-        comments_ = {}
-
-        for v in sorted(comments.values(), key=lambda x: x.addr):
-            comments_[hex(v.addr)] = v.__getstate__()
-        return comments_
-
-    def copy(self):
-        return Comment(
-            addr=self.addr,
-            comment=self.comment,
-            func_addr=self.func_addr,
-            decompiled=self.decompiled,
-            last_change=self.last_change
-        )
 
     def nonconflict_merge(self, obj2: "Comment", **kwargs) -> "Comment":
         obj1: "Comment" = self.copy()

--- a/libbs/artifacts/decompilation.py
+++ b/libbs/artifacts/decompilation.py
@@ -10,8 +10,14 @@ class Decompilation(Artifact):
         "decompiler",
     )
 
-    def __init__(self, addr, decompilation, decompiler=None, last_change=None):
-        super().__init__(last_change=last_change)
+    def __init__(
+        self,
+        addr: int = None,
+        decompilation: str = None,
+        decompiler: str = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
         self.addr = addr
         self.decompilation = decompilation
         self.decompiler = decompiler
@@ -21,9 +27,3 @@ class Decompilation(Artifact):
 
     def __repr__(self):
         return f"<Decompilation: {self.decompiler}@{hex(self.addr)} len={len(self.decompilation)}>"
-
-    @classmethod
-    def parse(cls, s):
-        dec = Decompilation(None, None)
-        dec.__setstate__(toml.loads(s))
-        return dec

--- a/libbs/artifacts/enum.py
+++ b/libbs/artifacts/enum.py
@@ -1,10 +1,7 @@
 from collections import OrderedDict
 from typing import Dict
 
-import toml
-
 from .artifact import Artifact
-from .formatting import ArtifactFormat
 
 
 class Enum(Artifact):
@@ -30,25 +27,6 @@ class Enum(Artifact):
     @staticmethod
     def _order_members(members):
         return OrderedDict(sorted(members.items(), key=lambda kv: kv[1]))
-
-    @classmethod
-    def load_many(cls, enums_toml):
-        for enum_toml in enums_toml.values():
-            enum = Enum(None, {})
-            try:
-                enum.__setstate__(enum_toml)
-            except TypeError:
-                # skip all incorrect ones
-                continue
-            yield enum
-
-    @classmethod
-    def dump_many(cls, enums):
-        enums_ = {}
-
-        for name, enum in enums.items():
-            enums_[name] = enum.__getstate__()
-        return enums_
 
     def nonconflict_merge(self, enum2: "Enum", **kwargs):
         enum1: Enum = self.copy()

--- a/libbs/artifacts/formatting.py
+++ b/libbs/artifacts/formatting.py
@@ -1,0 +1,28 @@
+from enum import StrEnum
+import typing
+
+from toml import TomlEncoder
+
+if typing.TYPE_CHECKING:
+    from ..api import CTypeParser, CType
+
+
+class ArtifactFormat(StrEnum):
+    TOML = "toml"
+    JSON = "json"
+    C_LANG = "c"
+
+
+class TomlHexEncoder(TomlEncoder):
+    def __init__(self, _dict=dict, preserve=False):
+        super(TomlHexEncoder, self).__init__(_dict, preserve=preserve)
+        self.dump_funcs[int] = lambda v: hex(v) if v >= 0 else v
+
+
+def ctype_from_size(size, type_parser: typing.Optional["CTypeParser"] = None) -> "CType":
+    if type_parser is None:
+        from ..api.type_parser import CTypeParser
+        type_parser = CTypeParser()
+
+    ctype = type_parser.size_to_type(size)
+    return ctype

--- a/libbs/artifacts/formatting.py
+++ b/libbs/artifacts/formatting.py
@@ -1,4 +1,3 @@
-from enum import StrEnum
 import typing
 
 from toml import TomlEncoder
@@ -7,7 +6,7 @@ if typing.TYPE_CHECKING:
     from ..api import CTypeParser, CType
 
 
-class ArtifactFormat(StrEnum):
+class ArtifactFormat:
     TOML = "toml"
     JSON = "json"
     C_LANG = "c"

--- a/libbs/artifacts/func.py
+++ b/libbs/artifacts/func.py
@@ -230,6 +230,12 @@ class Function(Artifact):
         return state
 
     def __setstate__(self, state):
+        # XXX: this is a backport of the old state format. Remove this after a few releases.
+        if "metadata" in state:
+            metadata: Dict = state.pop("metadata")
+            metadata.update(state)
+            state = metadata
+
         header_dat = state.pop("header", None)
         if header_dat:
             header = FunctionHeader()

--- a/libbs/artifacts/func.py
+++ b/libbs/artifacts/func.py
@@ -47,7 +47,7 @@ class FunctionHeader(Artifact):
         name: str = None,
         addr: int = None,
         type_: str = None,
-        args: Optional[Dict[str, FunctionArgument]] = None,
+        args: Optional[Dict[int, FunctionArgument]] = None,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -57,7 +57,7 @@ class FunctionHeader(Artifact):
         self.args: Dict = args or {}
 
     def __str__(self):
-        return f"<FuncHeader: {self.type} {self.name}(args={len(self.args)}); @{hex(self.addr)}>"
+        return f"<FuncHeader: {self.type} {self.name}(args={len(self.args or {})}); @{hex(self.addr)}>"
 
     def __getstate__(self):
         data_dict = super().__getstate__()
@@ -65,7 +65,7 @@ class FunctionHeader(Artifact):
         if args_dict is None:
             return data_dict
 
-        new_args_dict = {hex(k): v for k, v in args_dict.items()}
+        new_args_dict = {hex(k): v.__getstate__() for k, v in args_dict.items()}
         data_dict["args"] = new_args_dict
         return data_dict
 
@@ -247,7 +247,7 @@ class Function(Artifact):
                 stack_vars[int(off, 0)] = sv
         else:
             stack_vars = None
-        self.stack_vars = stack_vars
+        self.stack_vars = stack_vars or {}
 
         super().__setstate__(state)
 

--- a/libbs/artifacts/global_variable.py
+++ b/libbs/artifacts/global_variable.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import toml
 
 from .artifact import Artifact
@@ -11,8 +13,15 @@ class GlobalVariable(Artifact):
         "size"
     )
 
-    def __init__(self, addr, name, type_=None, size=0, last_change=None):
-        super(GlobalVariable, self).__init__(last_change=last_change)
+    def __init__(
+        self,
+        addr: int = None,
+        name: str = None,
+        type_: Optional[str] = None,
+        size: int = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
         self.addr = addr
         self.name = name
         self.type = type_
@@ -20,15 +29,6 @@ class GlobalVariable(Artifact):
 
     def __str__(self):
         return f"<GlobalVar: {self.type} {self.name}; @{self.addr} len={self.size}>"
-
-    def __repr__(self):
-        return self.__str__()
-
-    @classmethod
-    def parse(cls, s):
-        gv = GlobalVariable(None, None)
-        gv.__setstate__(toml.loads(s))
-        return gv
 
     @classmethod
     def load_many(cls, gvars_toml):
@@ -48,7 +48,3 @@ class GlobalVariable(Artifact):
         for v in sorted(global_vars.values(), key=lambda x: x.addr):
             global_vars_[hex(v.addr)] = v.__getstate__()
         return global_vars_
-
-    def copy(self):
-        gvar = GlobalVariable(self.addr, self.name, type_=self.type, size=self.size, last_change=self.last_change)
-        return gvar

--- a/libbs/artifacts/global_variable.py
+++ b/libbs/artifacts/global_variable.py
@@ -29,22 +29,3 @@ class GlobalVariable(Artifact):
 
     def __str__(self):
         return f"<GlobalVar: {self.type} {self.name}; @{self.addr} len={self.size}>"
-
-    @classmethod
-    def load_many(cls, gvars_toml):
-        for gvar_toml in gvars_toml.values():
-            global_var = GlobalVariable(None, None)
-            try:
-                global_var.__setstate__(gvar_toml)
-            except TypeError:
-                # skip all incorrect ones
-                continue
-            yield global_var
-
-    @classmethod
-    def dump_many(cls, global_vars):
-        global_vars_ = {}
-
-        for v in sorted(global_vars.values(), key=lambda x: x.addr):
-            global_vars_[hex(v.addr)] = v.__getstate__()
-        return global_vars_

--- a/libbs/artifacts/patch.py
+++ b/libbs/artifacts/patch.py
@@ -40,21 +40,3 @@ class Patch(Artifact):
         if bytes_dat:
             self.bytes = codecs.decode(bytes_dat, "hex")
         super().__setstate__(state)
-
-    @classmethod
-    def load_many(cls, patches_toml):
-        for patch_toml in patches_toml.values():
-            patch = Patch(None, None, None)
-            try:
-                patch.__setstate__(patch_toml)
-            except TypeError:
-                # skip all incorrect ones
-                continue
-            yield patch
-
-    @classmethod
-    def dump_many(cls, patches):
-        patches_ = {}
-        for v in patches.values():
-            patches_[hex(v.addr)] = v.__getstate__()
-        return patches_

--- a/libbs/artifacts/stack_variable.py
+++ b/libbs/artifacts/stack_variable.py
@@ -16,42 +16,24 @@ class StackVariable(Artifact):
         "addr",
     )
 
-    def __init__(self, stack_offset, name, type_, size, addr, last_change=None):
-        super(StackVariable, self).__init__(last_change=last_change)
-        self.offset = stack_offset  # type: int
-        self.name = name  # type: str
-        self.type = type_  # type: str
-        self.size = size  # type: int
-        self.addr = addr  # type: int
-        self.last_change = last_change
-
-    def __eq__(self, other):
-        # ignore time and offset type
-        if isinstance(other, StackVariable):
-            return other.offset == self.offset \
-                   and other.name == self.name \
-                   and other.type == self.type \
-                   and other.size == self.size \
-                   and other.addr == self.addr
-        return False
+    def __init__(
+        self,
+        stack_offset: int = None,
+        name: str = None,
+        type_: str = None,
+        size: int = None,
+        addr: int = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.offset = stack_offset
+        self.name = name
+        self.type = type_
+        self.size = size
+        self.addr = addr
 
     def __str__(self):
         return f"<StackVar: {self.type} {self.name}; {hex(self.offset)}@{hex(self.addr)}>"
-
-    def __repr__(self):
-        return self.__str__()
-
-    def copy(self):
-        return StackVariable(
-            self.offset, self.name, self.type, self.size, self.addr,
-            last_change=self.last_change
-        )
-
-    @classmethod
-    def parse(cls, s):
-        sv = StackVariable(None, None, None, None, None)
-        sv.__setstate__(toml.loads(s))
-        return sv
 
     @classmethod
     def load_many(cls, svs_toml):

--- a/libbs/artifacts/struct.py
+++ b/libbs/artifacts/struct.py
@@ -74,12 +74,20 @@ class Struct(Artifact):
         return data_dict
 
     def __setstate__(self, state):
+        # XXX: this is a backport of the old state format. Remove this after a few releases.
+        if "metadata" in state:
+            metadata: Dict = state.pop("metadata")
+            metadata.update(state)
+            state = metadata
+
         members_dat = state.pop("members", None)
         if members_dat:
             for off, member in members_dat.items():
                 sm = StructMember()
                 sm.__setstate__(member)
                 self.members[int(off, 0)] = sm
+        else:
+            self.members = {}
         super().__setstate__(state)
 
     def add_struct_member(self, mname, moff, mtype, size):

--- a/libbs/artifacts/struct.py
+++ b/libbs/artifacts/struct.py
@@ -1,8 +1,9 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import toml
 
-from .artifact import Artifact, TomlHexEncoder
+from .artifact import Artifact
+from . import TomlHexEncoder
 
 import logging
 l = logging.getLogger(name=__name__)
@@ -20,8 +21,15 @@ class StructMember(Artifact):
         "size",
     )
 
-    def __init__(self, name, offset, type_, size, last_change=None):
-        super(StructMember, self).__init__(last_change=last_change)
+    def __init__(
+        self,
+        name: str = None,
+        offset: int = None,
+        type_: Optional[str] = None,
+        size: int = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
         self.name: str = name
         self.offset: int = offset
         self.type: str = type_
@@ -29,25 +37,6 @@ class StructMember(Artifact):
 
     def __str__(self):
         return f"<StructMember: {self.type} {self.name}; @{hex(self.offset)}>"
-
-    def __repr__(self):
-        return self.__str__()
-
-    @classmethod
-    def parse(cls, s):
-        sm = StructMember(None, None, None, None)
-        sm.__setstate__(toml.loads(s))
-        return sm
-
-    def copy(self):
-        sm = StructMember(
-            self.name,
-            self.offset,
-            self.type,
-            self.size
-        )
-
-        return sm
 
 
 class Struct(Artifact):
@@ -61,40 +50,37 @@ class Struct(Artifact):
         "members",
     )
 
-    def __init__(self, name: str, size: int, members: Dict[int, StructMember], last_change=None):
-        super(Struct, self).__init__(last_change=last_change)
+    def __init__(
+        self,
+        name: str = None,
+        size: int = None,
+        members: Dict[int, StructMember] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
         self.name = name
         self.size = size or 0
-        self.members: Dict[int, StructMember] = members
+        self.members: Dict[int, StructMember] = members or {}
 
     def __str__(self):
         return f"<Struct: {self.name} membs={len(self.members)} ({hex(self.size)})>"
 
-    def __repr__(self):
-        return self.__str__()
-
     def __getstate__(self):
-        return {
-            "metadata": {
-                "name": self.name, "size": self.size, "last_change": self.last_change
-            },
-
-            "members": {
-                hex(offset): member.__getstate__() for offset, member in self.members.items()
-            }
+        data_dict = super().__getstate__()
+        data_dict["members"] = {
+            hex(offset): member.__getstate__() for offset, member in self.members.items()
         }
+
+        return data_dict
 
     def __setstate__(self, state):
-        metadata = state["metadata"]
-        members = state["members"]
-
-        self.name = metadata["name"]
-        self.size = metadata["size"]
-        self.last_change = metadata.get("last_change", None)
-
-        self.members = {
-            int(off, 16): StructMember.parse(toml.dumps(member, encoder=TomlHexEncoder())) for off, member in members.items()
-        }
+        members_dat = state.pop("members", None)
+        if members_dat:
+            for off, member in members_dat.items():
+                sm = StructMember()
+                sm.__setstate__(member)
+                self.members[int(off, 0)] = sm
+        super().__setstate__(state)
 
     def add_struct_member(self, mname, moff, mtype, size):
         self.members[moff] = StructMember(mname, moff, mtype, size)
@@ -130,23 +116,6 @@ class Struct(Artifact):
             diff_dict["members"][off] = self.invert_diff(other_mem.diff(None))
 
         return diff_dict
-
-    def copy(self):
-        members = {offset: member.copy() for offset, member in self.members.items()}
-        struct = Struct(self.name, self.size, members, last_change=self.last_change)
-        return struct
-
-    @classmethod
-    def parse(cls, s):
-        struct = Struct(None, None, None)
-        struct.__setstate__(s)
-        return struct
-
-    @classmethod
-    def load(cls, struct_toml):
-        s = Struct(None, None, None)
-        s.__setstate__(struct_toml)
-        return s
 
     def nonconflict_merge(self, struct2: "Struct", **kwargs) -> "Struct":
         struct1: "Struct" = self.copy()

--- a/libbs/decompilers/angr/compat.py
+++ b/libbs/decompilers/angr/compat.py
@@ -114,10 +114,12 @@ class GenericBSAngrManagementPlugin(BasePlugin):
         func_args = AngrInterface.func_args_as_libbs_args(decompilation)
         self.interface.function_header_changed(
             FunctionHeader(
-                None,
-                func.addr,
+                name=None,
+                addr=func.addr,
                 type_=None,
-                args={offset: FunctionArgument(offset, new_name, None, func_args[offset].size)},
+                args={
+                    offset: FunctionArgument(offset=offset, name=new_name, type_=None, size=func_args[offset].size)
+                },
             )
         )
 
@@ -129,10 +131,12 @@ class GenericBSAngrManagementPlugin(BasePlugin):
         func_args = AngrInterface.func_args_as_libbs_args(decompilation)
         self.interface.function_header_changed(
             FunctionHeader(
-                None,
-                func.addr,
+                name=None,
+                addr=func.addr,
                 type_=None,
-                args={offset: FunctionArgument(offset, None, new_type, func_args[offset].size)},
+                args={
+                    offset: FunctionArgument(offset=offset, name=None, type_=new_type, size=func_args[offset].size)
+                },
             )
         )
 
@@ -141,14 +145,14 @@ class GenericBSAngrManagementPlugin(BasePlugin):
     # pylint: disable=unused-argument,no-self-use
     def handle_global_var_renamed(self, address, old_name, new_name):
         self.interface.global_variable_changed(
-            GlobalVariable(address, new_name, type_=None)
+            GlobalVariable(addr=address, name=new_name, type_=None)
         )
         return True
 
     # pylint: disable=unused-argument,no-self-use
     def handle_global_var_retyped(self, address, old_type, new_type):
         self.interface.global_variable_changed(
-            GlobalVariable(address, None, type_=new_type)
+            GlobalVariable(addr=address, name=None, type_=new_type)
         )
         return True
 
@@ -157,7 +161,7 @@ class GenericBSAngrManagementPlugin(BasePlugin):
         if func is None:
             return False
 
-        self.interface.function_header_changed(FunctionHeader(new_name, func.addr))
+        self.interface.function_header_changed(FunctionHeader(name=new_name, addr=func.addr))
         return True
 
     # pylint: disable=unused-argument,no-self-use
@@ -165,7 +169,7 @@ class GenericBSAngrManagementPlugin(BasePlugin):
         if func is None:
             return False
 
-        self.interface.function_header_changed(FunctionHeader(None, func.addr, type_=new_type))
+        self.interface.function_header_changed(FunctionHeader(name=None, addr=func.addr, type_=new_type))
         return True
 
     # pylint: disable=unused-argument
@@ -176,6 +180,6 @@ class GenericBSAngrManagementPlugin(BasePlugin):
             return False
 
         self.interface.comment_changed(
-            Comment(address, new_cmt, func_addr=func_addr, decompiled=True), deleted=not new_cmt
+            Comment(addr=address, comment=new_cmt, func_addr=func_addr, decompiled=True), deleted=not new_cmt
         )
         return True

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -284,7 +284,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
         args = {}
         if arg_variable_info:
             args = {
-                i: FunctionArgument(offset=i, name=info[0], type_=info[1], size=info[2], addr=addr) for i, info in enumerate(arg_variable_info)
+                i: FunctionArgument(offset=i, name=info[0], type_=info[1], size=info[2]) for i, info in enumerate(arg_variable_info)
             }
 
         # grab the return type of the function from ghidra

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -275,7 +275,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
                 stack_variable_info
             }
 
-        arg_variable_info: Optional[List[Tuple[int, str, str, int]]] = self.ghidra.bridge.remote_eval(
+        arg_variable_info: Optional[List[Tuple[str, str, int]]] = self.ghidra.bridge.remote_eval(
             "[(sym.getName(), str(sym.getDataType()), sym.getSize()) "
             "for sym in dec.getHighFunction().getLocalSymbolMap().getSymbols() "
             "if sym.isParameter()]",
@@ -284,7 +284,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
         args = {}
         if arg_variable_info:
             args = {
-                i: FunctionArgument(i, info[0], info[1], info[2], addr) for i, info in enumerate(arg_variable_info)
+                i: FunctionArgument(offset=i, name=info[0], type_=info[1], size=info[2], addr=addr) for i, info in enumerate(arg_variable_info)
             }
 
         # grab the return type of the function from ghidra
@@ -718,8 +718,8 @@ class GhidraDecompilerInterface(DecompilerInterface):
             return None
 
         bs_func = Function(
-            gfunc.getEntryPoint().getOffset(), gfunc.getBody().getNumAddresses(),
-            header=FunctionHeader(gfunc.getName(), gfunc.getEntryPoint().getOffset()),
+            addr=gfunc.getEntryPoint().getOffset(), size=gfunc.getBody().getNumAddresses(),
+            header=FunctionHeader(name=gfunc.getName(), addr=gfunc.getEntryPoint().getOffset()),
         )
         return bs_func
 

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -769,7 +769,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
         dt_service = aam.getDataTypeManagerService()
         dt_parser = dtp_class(dt_service, dtp_class.AllowedDataTypes.ALL)
         try:
-            parsed_type = dt_parser.loads(typestr)
+            parsed_type = dt_parser.parse(typestr)
         except Exception as e:
             _l.warning(f"Failed to parse type string: {typestr}")
             return None

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -769,7 +769,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
         dt_service = aam.getDataTypeManagerService()
         dt_parser = dtp_class(dt_service, dtp_class.AllowedDataTypes.ALL)
         try:
-            parsed_type = dt_parser.parse(typestr)
+            parsed_type = dt_parser.loads(typestr)
         except Exception as e:
             _l.warning(f"Failed to parse type string: {typestr}")
             return None

--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -200,7 +200,7 @@ def functions():
 
         func_name = get_func_name(func_addr)
         func_size = get_func_size(func_addr)
-        func = Function(func_addr, func_size)
+        func = Function(addr=func_addr, size=func_size)
         func.name = func_name
         funcs[func_addr] = func
 

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -3,34 +3,41 @@ import json
 
 import unittest
 
+import toml
 from libbs.artifacts import (
-    FunctionHeader, StackVariable, FunctionArgument, Function
+    FunctionHeader, StackVariable, FunctionArgument, Function, ArtifactFormat, Struct, StructMember
 )
 
+
+def generate_test_funcs(func_addr):
+    fh1 = FunctionHeader(name="main", addr=func_addr, type_="int *", args={
+        0: FunctionArgument(offset=0, name="a1", type_="int", size=4),
+        1: FunctionArgument(offset=1, name="a2", type_="long", size=8)
+    })
+    fh2 = FunctionHeader("binsync_main", func_addr, type_="long *", args={
+        0: FunctionArgument(offset=0, name="a1", type_="int", size=4),
+        1: FunctionArgument(offset=1, name="a2", type_="int", size=4)
+    })
+
+    stack_vars1 = {
+        0x0: StackVariable(stack_offset=0, name="v0", type_="int", size=4, addr=func_addr),
+        0x4: StackVariable(stack_offset=4, name="v4", type_="int", size=4, addr=func_addr)
+    }
+    stack_vars2 = {
+        0x0: StackVariable(stack_offset=0, name="v0", type_="int", size=4, addr=func_addr),
+        0x4: StackVariable(stack_offset=4, name="v4", type_="long", size=8, addr=func_addr),
+        0x8: StackVariable(stack_offset=8, name="v8", type_="long", size=8, addr=func_addr)
+    }
+
+    func1 = Function(addr=func_addr, size=0x100, header=fh1, stack_vars=stack_vars1)
+    func2 = Function(addr=func_addr, size=0x150, header=fh2, stack_vars=stack_vars2)
+    return func1, func2
 
 class TestArtifacts(unittest.TestCase):
     def test_func_diffing(self):
         # setup top
         func_addr = 0x400000
-        fh1 = FunctionHeader("main", func_addr, type_="int *", args={
-            0: FunctionArgument(0, "a1", "int", 4), 1: FunctionArgument(1, "a2", "long", 8)
-        })
-        fh2 = FunctionHeader("binsync_main", func_addr, type_="long *", args={
-            0: FunctionArgument(0, "a1", "int", 4), 1: FunctionArgument(1, "a2", "int", 4)
-        })
-
-        stack_vars1 = {
-            0x0: StackVariable(0, "v0", "int", 4, func_addr),
-            0x4: StackVariable(4, "v4", "int", 4, func_addr)
-        }
-        stack_vars2 = {
-            0x0: StackVariable(0, "v0", "int", 4, func_addr),
-            0x4: StackVariable(4, "v4", "long", 8, func_addr),
-            0x8: StackVariable(8, "v8", "long", 8, func_addr)
-        }
-
-        func1 = Function(func_addr, 0x100, header=fh1, stack_vars=stack_vars1)
-        func2 = Function(func_addr, 0x150, header=fh2, stack_vars=stack_vars2)
+        func1, func2 = generate_test_funcs(func_addr)
 
         diff_dict = func1.diff(func2)
         header_diff = diff_dict["header"]
@@ -63,26 +70,24 @@ class TestArtifacts(unittest.TestCase):
                 assert var_diff["addr"]["before"] is None
                 assert var_diff["addr"]["after"] == func1.addr
 
-        print(json.dumps(diff_dict, sort_keys=False, indent=4))
-
     def test_func_nonconflict_merge(self):
         # setup top
         func_addr = 0x400000
-        fh1 = FunctionHeader("user1_func", func_addr, type_="int *", args={})
-        fh2 = FunctionHeader("main", func_addr, type_="long *", args={})
+        fh1 = FunctionHeader(name="user1_func", addr=func_addr, type_="int *", args={})
+        fh2 = FunctionHeader(name="main", addr=func_addr, type_="long *", args={})
 
         stack_vars1 = {
-            0x0: StackVariable(0, "v0", "int", 4, func_addr),
-            0x4: StackVariable(4, "my_var", "int", 4, func_addr)
+            0x0: StackVariable(stack_offset=0, name="v0", type_="int", size=4, addr=func_addr),
+            0x4: StackVariable(stack_offset=4, name="my_var", type_="int", size=4, addr=func_addr)
         }
         stack_vars2 = {
-            0x0: StackVariable(0, "v0", "int", 4, func_addr),
-            0x4: StackVariable(4, "v4", "long", 8, func_addr),
-            0x8: StackVariable(8, "v8", "long", 8, func_addr)
+            0x0: StackVariable(stack_offset=0, name="v0", type_="int", size=4, addr=func_addr),
+            0x4: StackVariable(stack_offset=4, name="v4", type_="long", size=8, addr=func_addr),
+            0x8: StackVariable(stack_offset=8, name="v8", type_="long", size=8, addr=func_addr)
         }
 
-        func1 = Function(func_addr, 0x100, header=fh1, stack_vars=stack_vars1)
-        func2 = Function(func_addr, 0x100, header=fh2, stack_vars=stack_vars2)
+        func1 = Function(addr=func_addr, size=0x100, header=fh1, stack_vars=stack_vars1)
+        func2 = Function(addr=func_addr, size=0x100, header=fh2, stack_vars=stack_vars2)
         merge_func = func1.nonconflict_merge(func2)
 
         assert merge_func.name == "user1_func"
@@ -95,25 +100,25 @@ class TestArtifacts(unittest.TestCase):
     def test_func_overwrite_merge(self):
         func_addr = 0x400000
         func_size = 0x100
-        fh1 = FunctionHeader("main", func_addr, type_="int *", args={
-            0: FunctionArgument(0, "a1", "int", 4)
+        fh1 = FunctionHeader(name="main", addr=func_addr, type_="int *", args={
+            0: FunctionArgument(offset=0, name="a1", type_="int", size=4)
         })
-        fh2 = FunctionHeader("binsync_main", func_addr, type_="long *", args={
-            1: FunctionArgument(1, "bs_2", "int", 4)
+        fh2 = FunctionHeader(name="binsync_main", addr=func_addr, type_="long *", args={
+            1: FunctionArgument(offset=1, name="bs_2", type_="int", size=4)
         })
 
         stack_vars1 = {
-            0x0: StackVariable(0, "v0", "int", 4, func_addr),
-            0x4: StackVariable(4, "v4", "long", 8, func_addr),
-            0x8: StackVariable(8, "v8", "long", 8, func_addr)
+            0x0: StackVariable(stack_offset=0, name="v0", type_="int", size=4, addr=func_addr),
+            0x4: StackVariable(stack_offset=4, name="v4", type_="long", size=8, addr=func_addr),
+            0x8: StackVariable(stack_offset=8, name="v8", type_="long", size=8, addr=func_addr)
         }
         stack_vars2 = {
-            0x0: StackVariable(0, "v0", "long", 4, func_addr),
-            0x4: StackVariable(4, "my_var", "int", 4, func_addr)
+            0x0: StackVariable(stack_offset=0, name="v0", type_="long", size=4, addr=func_addr),
+            0x4: StackVariable(stack_offset=4, name="my_var", type_="int", size=4, addr=func_addr)
         }
 
-        func1 = Function(func_addr, func_size, header=fh1, stack_vars=stack_vars1)
-        func2 = Function(func_addr, func_size, header=fh2, stack_vars=stack_vars2)
+        func1 = Function(addr=func_addr, size=func_size, header=fh1, stack_vars=stack_vars1)
+        func2 = Function(addr=func_addr, size=func_size, header=fh2, stack_vars=stack_vars2)
 
         merge_func = func1.overwrite_merge(func2)
 
@@ -124,6 +129,42 @@ class TestArtifacts(unittest.TestCase):
         assert merge_func.stack_vars[0].type == stack_vars2[0].type
         assert merge_func.stack_vars[0x4] == stack_vars2[0x4]
         assert merge_func.stack_vars[0x8] == stack_vars1[0x8]
+
+    def test_serialization(self):
+        native_load_funcs = {
+            ArtifactFormat.JSON: json.loads,
+            ArtifactFormat.TOML: toml.loads
+        }
+
+        func, _ = generate_test_funcs(0x400000)
+        struct = Struct(name="some_struct", size=8, members={
+            0: StructMember(offset=0, name="m0", type_="int", size=4),
+            4: StructMember(offset=4, name="m4", type_="long", size=8)
+        })
+        for fmt, load_func in native_load_funcs.items():
+            serialized_func = func.dumps(fmt=fmt)
+            loaded_func_dict = load_func(serialized_func)
+
+            assert loaded_func_dict["addr"] == func.addr
+            assert loaded_func_dict["size"] == func.size
+            assert loaded_func_dict["header"]["name"] == func.header.name
+            assert loaded_func_dict["header"]["type"] == func.header.type
+            assert loaded_func_dict["header"]["args"]["0x0"]["name"] == func.header.args[0].name
+            # XXX: critical point: keys are strings, not integers
+            assert loaded_func_dict["stack_vars"]["0x0"]["name"] == func.stack_vars[0].name
+
+            loaded_func = Function.loads(serialized_func, fmt=fmt)
+            assert loaded_func == func
+
+            serialized_struct = struct.dumps(fmt=fmt)
+            loaded_struct_dict = load_func(serialized_struct)
+            assert loaded_struct_dict["name"] == struct.name
+            assert loaded_struct_dict["size"] == struct.size
+            assert loaded_struct_dict["members"]["0x0"]["name"] == struct.members[0].name
+            assert loaded_struct_dict["members"]["0x4"]["type"] == struct.members[4].type
+
+            loaded_struct = Struct.loads(serialized_struct, fmt=fmt)
+            assert loaded_struct == struct
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #70 

Adds support for the general formatting and serialization of Artifacts. This includes converting to TOML, JSON, and C.

## TODO
- [x] Update all instances of `dump_many` and `load_many`
- [x] Test the new format in BinSync