### PR TITLE
Cache binary_base_addr

### DIFF
--- a/libbs/__init__.py
+++ b/libbs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 
 import logging

--- a/libbs/api/artifact_lifter.py
+++ b/libbs/api/artifact_lifter.py
@@ -33,10 +33,11 @@ class ArtifactLifter:
         pass
 
     def lift_addr(self, addr: int) -> int:
-        if addr < self.deci.binary_base_addr:
+        base_addr = self.deci.binary_base_addr
+        if addr < base_addr:
             self.deci.warning(f"Lifting an address that appears already lifted: {addr}...")
 
-        return addr - self.deci.binary_base_addr
+        return addr - base_addr
 
     def lift_stack_offset(self, offset: int, func_addr: int) -> int:
         pass
@@ -45,10 +46,11 @@ class ArtifactLifter:
         pass
 
     def lower_addr(self, addr: int) -> int:
-        if addr >= self.deci.binary_base_addr:
+        base_addr = self.deci.binary_base_addr
+        if addr >= base_addr != 0:
             self.deci.warning(f"Lowering an address that appears already lowered: {addr}...")
 
-        return addr + self.deci.binary_base_addr
+        return addr + base_addr
 
     def lower_stack_offset(self, offset: int, func_addr: int) -> int:
         pass

--- a/libbs/decompilers/ghidra/compat/bridge.py
+++ b/libbs/decompilers/ghidra/compat/bridge.py
@@ -21,7 +21,7 @@ def connect_to_bridge(connection_timeout=20) -> Optional[ghidra_bridge.GhidraBri
     while time.time() - start_time < connection_timeout:
         try:
             bridge = ghidra_bridge.GhidraBridge(
-                namespace=globals(), interactive_mode=True, response_timeout=10
+                namespace=globals(), interactive_mode=True, response_timeout=30
             )
         except ConnectionError as e:
             _l.debug(f"Failed to connect to GhidraBridge: {e}")

--- a/libbs/decompilers/ghidra/compat/bridge.py
+++ b/libbs/decompilers/ghidra/compat/bridge.py
@@ -21,10 +21,10 @@ def connect_to_bridge(connection_timeout=20) -> Optional[ghidra_bridge.GhidraBri
     while time.time() - start_time < connection_timeout:
         try:
             bridge = ghidra_bridge.GhidraBridge(
-                namespace=globals(), interactive_mode=True
+                namespace=globals(), interactive_mode=True, response_timeout=10
             )
         except ConnectionError as e:
-            _l.info(f"Failed to connect to GhidraBridge: {e}")
+            _l.debug(f"Failed to connect to GhidraBridge: {e}")
             time.sleep(1)
 
         if bridge is not None:

--- a/libbs/decompilers/ghidra/hooks.py
+++ b/libbs/decompilers/ghidra/hooks.py
@@ -60,7 +60,10 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                 newValue = record.getNewValue()
                 obj = record.getObject()
 
-                if changeType in self.funcEvents:
+                if changeType == ChangeManager.DO_OBJECT_RENAMED:
+                    # TODO: Implement this, it should indicate a base addr changed
+                    pass
+                elif changeType in self.funcEvents:
                     subType = record.getSubEventType()
                     if subType == ChangeManager.FUNCTION_CHANGED_RETURN:
                         # Function return type changed

--- a/libbs/decompilers/ghidra/hooks.py
+++ b/libbs/decompilers/ghidra/hooks.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+from typing import Tuple, Optional
 import threading
 
 from ...artifacts import FunctionHeader, Function, FunctionArgument, StackVariable, GlobalVariable, Struct, Enum
@@ -20,22 +21,24 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
         def __init__(self, deci: "GhidraDecompilerInterface"):
             self._deci = deci
             # Init event lists
-            self.funcEvents = [
+            self.funcEvents = {
                 ChangeManager.DOCR_FUNCTION_CHANGED,
                 ChangeManager.DOCR_FUNCTION_BODY_CHANGED,
                 ChangeManager.DOCR_VARIABLE_REFERENCE_ADDED,
                 ChangeManager.DOCR_VARIABLE_REFERENCE_REMOVED
-            ]
+            }
 
-            self.symDelEvents = [ChangeManager.DOCR_SYMBOL_REMOVED]
+            self.symDelEvents = {
+                ChangeManager.DOCR_SYMBOL_REMOVED
+            }
 
-            self.symChgEvents = [
+            self.symChgEvents = {
                 ChangeManager.DOCR_SYMBOL_ADDED,
                 ChangeManager.DOCR_SYMBOL_RENAMED,
                 ChangeManager.DOCR_SYMBOL_DATA_CHANGED
-            ]
+            }
 
-            self.typeEvents = [
+            self.typeEvents = {
                 ChangeManager.DOCR_SYMBOL_ADDRESS_CHANGED,
                 ChangeManager.DOCR_DATA_TYPE_CHANGED,
                 ChangeManager.DOCR_DATA_TYPE_REPLACED,
@@ -43,13 +46,22 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                 ChangeManager.DOCR_DATA_TYPE_SETTING_CHANGED,
                 ChangeManager.DOCR_DATA_TYPE_MOVED,
                 ChangeManager.DOCR_DATA_TYPE_ADDED
-            ]
+            }
+
+            self.imageBaseEvents = {
+                ChangeManager.DOCR_IMAGE_BASE_CHANGED
+            }
+
+            self.TrackedEvents = (
+                self.funcEvents | self.symDelEvents | self.symChgEvents | self.typeEvents | self.imageBaseEvents
+            )
 
         def domainObjectChanged(self, ev):
             try:
                 self.do_change_handler(ev)
             except Exception as e:
-                _l.exception("Error in domainObjectChanged: %s", e)
+                excep_str = str(e).replace('\n', ' ')
+                self._deci.error(f"Error in domainObjectChanged: {excep_str}")
 
         def do_change_handler(self, ev):
             for record in ev:
@@ -57,13 +69,13 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                     continue
 
                 changeType = record.getEventType()
-                newValue = record.getNewValue()
-                obj = record.getObject()
+                if changeType not in self.TrackedEvents:
+                    # bail out early if we don't care about this event
+                    continue
 
-                if changeType == ChangeManager.DO_OBJECT_RENAMED:
-                    # TODO: Implement this, it should indicate a base addr changed
-                    pass
-                elif changeType in self.funcEvents:
+                new_value = record.getNewValue()
+                obj = record.getObject()
+                if changeType in self.funcEvents:
                     subType = record.getSubEventType()
                     if subType == ChangeManager.FUNCTION_CHANGED_RETURN:
                         # Function return type changed
@@ -79,7 +91,7 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                             parent_namespace = obj.getParentNamespace()
                             storage = obj.getVariableStorage()
                             if (
-                                    (newValue is not None) and (storage is not None) and bool(storage.isStackStorage())
+                                    (new_value is not None) and (storage is not None) and bool(storage.isStackStorage())
                                     and (parent_namespace is not None)
                             ):
                                 sv = StackVariable(
@@ -95,7 +107,7 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
 
                     else:
                         try:
-                            struct = self._deci.structs[newValue.name]
+                            struct = self._deci.structs[new_value.name]
                             # TODO: access old name indicate deletion
                             # self._deci.struct_changed(Struct(None, None, None), deleted=True)
                             self._deci.struct_changed(struct)
@@ -107,7 +119,7 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                             parent_namespace = obj.getParentNamespace()
                             storage = obj.getVariableStorage()
                             if (
-                                    (newValue is not None) and (storage is not None) and bool(storage.isStackStorage())
+                                    (new_value is not None) and (storage is not None) and bool(storage.isStackStorage())
                                     and (parent_namespace is not None)
                             ):
                                 self._deci.stack_variable_changed(
@@ -122,7 +134,7 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
 
                     else:
                         try:
-                            struct = self._deci.structs[newValue.name]
+                            struct = self._deci.structs[new_value.name]
                             # TODO: access old name indicate deletion
                             # self._deci.struct_changed(Struct(None, None, None), deleted=True)
                             self._deci.struct_changed(struct)
@@ -130,7 +142,7 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                             pass
 
                         try:
-                            enum = self._deci.enums[newValue.name]
+                            enum = self._deci.enums[new_value.name]
                             # self._deci.enum_changed(Enum(None, None), deleted=True)
                             self._deci.enum_changed(enum)
                         except KeyError:
@@ -144,8 +156,8 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                         self._deci.global_variable_changed(removed, deleted=True)
                 elif changeType in self.symChgEvents:
                     # For creation events, obj is stored in newValue
-                    if obj is None and newValue is not None:
-                        obj = newValue
+                    if obj is None and new_value is not None:
+                        obj = new_value
 
                     if changeType == ChangeManager.DOCR_SYMBOL_ADDED:
                         if self._deci.isinstance(obj, CodeSymbol):
@@ -153,22 +165,22 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                             self._deci.global_variable_changed(gvar)
                     elif changeType == ChangeManager.DOCR_SYMBOL_RENAMED:
                         if self._deci.isinstance(obj, CodeSymbol):
-                            gvar = GlobalVariable(obj.getAddress().getOffset(), newValue)
+                            gvar = GlobalVariable(obj.getAddress().getOffset(), new_value)
                             self._deci.global_variable_changed(gvar)
                         if self._deci.isinstance(obj, FunctionSymbol):
-                            header = FunctionHeader(name=newValue, addr=int(obj.getAddress().offset))
+                            header = FunctionHeader(name=new_value, addr=int(obj.getAddress().offset))
                             self._deci.function_header_changed(header)
                     elif self._deci.isinstance(obj, VariableDB):
                         parent_namespace = obj.getParentNamespace()
                         storage = obj.getVariableStorage()
                         if (
-                                (newValue is not None) and (storage is not None) and bool(storage.isStackStorage())
+                                (new_value is not None) and (storage is not None) and bool(storage.isStackStorage())
                                 and (parent_namespace is not None)
                         ):
                             self._deci.stack_variable_changed(
                                 StackVariable(
                                     int(obj.variableStorage.stackOffset),
-                                    newValue,
+                                    new_value,
                                     None,
                                     None,
                                     int(obj.parentNamespace.entryPoint.offset)
@@ -182,6 +194,10 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
                         pass
                     else:
                         continue
+                elif changeType in self.imageBaseEvents:
+                    new_base_addr = int(new_value.getOffset()) if new_value is not None else None
+                    if new_base_addr is not None:
+                        self._deci._binary_base_addr = new_base_addr
 
     data_monitor = DataMonitor(deci)
     return data_monitor

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -54,7 +54,6 @@ class GhidraDecompilerInterface(DecompilerInterface):
         self._last_addr = None
         self._last_func = None
         self._binary_base_addr = None
-        self._last_base_addr_access = time.time()
         self._default_pointer_size = None
 
         super().__init__(
@@ -213,10 +212,8 @@ class GhidraDecompilerInterface(DecompilerInterface):
 
     @property
     def binary_base_addr(self) -> int:
-        # TODO: this is a hack for a dumb cache, and can cause bugs, but good enough for now:
-        if (time.time() - self._last_base_addr_access > self.CACHE_TIMEOUT) or self._binary_base_addr is None:
+        if self._binary_base_addr is None:
             self._binary_base_addr = int(self.currentProgram.getImageBase().getOffset())
-            self._last_base_addr_access = time.time()
 
         return self._binary_base_addr
 

--- a/libbs/decompilers/ida/hooks.py
+++ b/libbs/decompilers/ida/hooks.py
@@ -131,7 +131,7 @@ class IDAHotkeyHook(ida_kernwin.UI_Hooks):
 #
 
 class IDBHooks(ida_idp.IDB_Hooks):
-    def __init__(self, interface):
+    def __init__(self, interface=None):
         ida_idp.IDB_Hooks.__init__(self)
         self.interface: "IDAInterface" = interface
         self._seen_function_prototypes = {}
@@ -403,6 +403,16 @@ class IDBHooks(ida_idp.IDB_Hooks):
         return 0
 
     #
+    # Others
+    #
+
+    @while_should_watch
+    def segm_moved(self, from_, to, size, changed_netmap):
+        if from_ == self.interface.binary_base_addr:
+            _l.info("Detected a change in the binary base address! Updating it to %d", to)
+            self.interface._binary_base_addr = to
+
+    #
     # Unused handlers, to be implemented eventually
     #
 
@@ -433,7 +443,7 @@ class IDBHooks(ida_idp.IDB_Hooks):
 
 
 class IDPHooks(ida_idp.IDP_Hooks):
-    def __init__(self, interface):
+    def __init__(self, interface=None):
         self.interface: "IDAInterface" = interface
         ida_idp.IDP_Hooks.__init__(self)
 

--- a/libbs/decompilers/ida/hooks.py
+++ b/libbs/decompilers/ida/hooks.py
@@ -406,9 +406,8 @@ class IDBHooks(ida_idp.IDB_Hooks):
     # Others
     #
 
-    @while_should_watch
     def segm_moved(self, from_, to, size, changed_netmap):
-        if from_ == self.interface.binary_base_addr:
+        if self.interface is not None and from_ == self.interface.binary_base_addr:
             _l.info("Detected a change in the binary base address! Updating it to %d", to)
             self.interface._binary_base_addr = to
 

--- a/libbs/decompilers/ida/hooks.py
+++ b/libbs/decompilers/ida/hooks.py
@@ -131,7 +131,7 @@ class IDAHotkeyHook(ida_kernwin.UI_Hooks):
 #
 
 class IDBHooks(ida_idp.IDB_Hooks):
-    def __init__(self, interface=None):
+    def __init__(self, interface):
         ida_idp.IDB_Hooks.__init__(self)
         self.interface: "IDAInterface" = interface
         self._seen_function_prototypes = {}
@@ -403,15 +403,6 @@ class IDBHooks(ida_idp.IDB_Hooks):
         return 0
 
     #
-    # Others
-    #
-
-    def segm_moved(self, from_, to, size, changed_netmap):
-        if self.interface is not None and from_ == self.interface.binary_base_addr:
-            _l.info("Detected a change in the binary base address! Updating it to %d", to)
-            self.interface._binary_base_addr = to
-
-    #
     # Unused handlers, to be implemented eventually
     #
 
@@ -442,7 +433,7 @@ class IDBHooks(ida_idp.IDB_Hooks):
 
 
 class IDPHooks(ida_idp.IDP_Hooks):
-    def __init__(self, interface=None):
+    def __init__(self, interface):
         self.interface: "IDAInterface" = interface
         ida_idp.IDP_Hooks.__init__(self)
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -28,6 +28,7 @@ class IDAInterface(DecompilerInterface):
         self._ctx_menu_names = []
         self._ui_hooks = []
         self._artifact_watcher_hooks = []
+        self._binary_base_addr = None
 
         super().__init__(
             name="ida", qt_version="PyQt5", artifact_lifter=IDAArtifactLifter(self),
@@ -93,7 +94,11 @@ class IDAInterface(DecompilerInterface):
 
     @property
     def binary_base_addr(self) -> int:
-        return compat.get_image_base()
+        if self._binary_base_addr is None:
+            self._binary_base_addr = compat.get_image_base()
+
+        # use the cache
+        return self._binary_base_addr
 
     @property
     def binary_hash(self) -> str:
@@ -156,11 +161,11 @@ class IDAInterface(DecompilerInterface):
 
     def start_artifact_watchers(self):
         self._artifact_watcher_hooks = [
-            IDBHooks(self),
+            IDBHooks(interface=self),
             # this hook is special because it relies on the decompiler being present, which can only be checked
             # after the plugin loading phase. this means the user will need to manually init this hook in the UI
             # either through scripting or a UI.
-            HexraysHooks(self),
+            HexraysHooks(interface=self),
         ]
         for hook in self._artifact_watcher_hooks:
             hook.hook()

--- a/tests/test_remote_ghidra.py
+++ b/tests/test_remote_ghidra.py
@@ -38,19 +38,6 @@ class TestRemoteGhidra(unittest.TestCase):
             self.deci = deci
 
             #
-            # Test Image Base Watcher
-            #
-
-            original_base_addr = deci.binary_base_addr
-            new_base_addr = 0x1000000
-            with Transaction(deci.flat_api, msg="BS::test_ghidra_artifact_watchers"):
-                deci.flat_api.currentProgram.setImageBase(deci.flat_api.toAddr(new_base_addr), True)
-
-            time.sleep(0.5)
-            assert deci.binary_base_addr != original_base_addr
-            assert deci.binary_base_addr == new_base_addr
-
-            #
             # Test Artifact Watchers
             #
 
@@ -117,6 +104,19 @@ class TestRemoteGhidra(unittest.TestCase):
             # deci.functions[func_addr] = main
 
             # assert hits[Struct] == 2 # One change results in 2 hits because the struct is first removed and then added again.
+
+            #
+            # Test Image Base Watcher
+            #
+
+            original_base_addr = deci.binary_base_addr
+            new_base_addr = 0x1000000
+            with Transaction(deci.flat_api, msg="BS::test_ghidra_artifact_watchers"):
+                deci.flat_api.currentProgram.setImageBase(deci.flat_api.toAddr(new_base_addr), True)
+
+            time.sleep(0.5)
+            assert deci.binary_base_addr != original_base_addr
+            assert deci.binary_base_addr == new_base_addr
 
             deci.shutdown()
 

--- a/tests/test_remote_ghidra.py
+++ b/tests/test_remote_ghidra.py
@@ -111,6 +111,7 @@ class TestRemoteGhidra(unittest.TestCase):
 
             original_base_addr = deci.binary_base_addr
             new_base_addr = 0x1000000
+            # NOTE: if this code is continuously flaky, we can remove it
             with Transaction(deci.flat_api, msg="BS::test_ghidra_artifact_watchers"):
                 deci.flat_api.currentProgram.setImageBase(deci.flat_api.toAddr(new_base_addr), True)
 


### PR DESCRIPTION
Closes #78 

## TODO:
- [X] Working IDA
- [x] Finish Ghidra 
- [x] Implement Binja
- [x] Add some note in the angr interface that there is no need for caching

## Important Findings
After doing some measuring, it turns out that requesting the base addr through IDA Proj `idaapi.get_baseaddr()`, usually took `0.002` seconds, which is great. So great, in fact, that the complexity of writing a normal handler for baseaddr changes was undeeded. I've saved that progress in the https://github.com/binsync/libbs/tree/feat/ida_baseaddr_callback branch if it's ever needed again.

Similarly, the Binja and angr native Python APIs are very fast. Only Ghidra needed a real caching system to keep up with speed, so this PR only does that. 

After this change, we should be seeing another big speedup in dumping of mass functions, since the baseaddr was always requested when using these APIs. 
