### PR TITLE
IDA: ignore decompilation failures

### DIFF
--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -1213,7 +1213,9 @@ def acquire_pseudocode_vdui(addr):
         vu = ida_hexrays.open_pseudocode(func.start_ea, False)
 
     if func.start_ea != vu.cfunc.entry_ea:
-        target_cfunc = idaapi.decompile(func.start_ea)
+        target_cfunc = ida_hexrays.decompile(func.start_ea)
+        if target_cfunc is None:
+            return None
         vu.switch_to(target_cfunc, False)
     else:
         vu.refresh_view(True)
@@ -1252,6 +1254,8 @@ class IDAViewCTX:
 
     @execute_write
     def close_pseudocode_view(self, ida_vdui_t):
+        if ida_vdui_t is None:
+            return
         widget = ida_vdui_t.toplevel
         idaapi.close_pseudocode(widget)
 

--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -84,7 +84,7 @@ def execute_write(f):
 
 class DummyIDACodeView:
     def __init__(self, addr):
-        self.cfunc = idaapi.decompile(addr)
+        self.cfunc = ida_hexrays.decompile(addr)
         self.addr = addr
 
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -150,7 +150,7 @@ class IDAInterface(DecompilerInterface):
 
     def get_decompilation_object(self, function: Function, do_lower=True, **kwargs) -> Optional[object]:
         function = self.art_lifter.lower(function) if do_lower else function
-        dec = idaapi.decompile(function.addr)
+        dec = ida_hexrays.decompile(function.addr)
         if dec is None:
             return None
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -159,6 +159,8 @@ class IDAInterface(DecompilerInterface):
     def _decompile(self, function: Function, map_lines=False, **kwargs) -> Optional[Decompilation]:
         try:
             cfunc = ida_hexrays.decompile(function.addr)
+            if cfunc is None:
+                return None
         except Exception:
             return None
 


### PR DESCRIPTION
This commit fixes issues found in `ida/compat.py` in `acquire_pseudocode_vdui`. If a function cannot be decompiled, IDA will complain about a null reference in method `vdui_t_switch_to`, preventing the plugin to complete his tasks.

**NOTE:** When the error occurs, `ida_hexrays.decompile(...)` does not raise an exception. It only returns `None`, that is why we check the return code for all of them and return early on `None`. 
