### PR TITLE
Fixed IDA struct member type change

### DIFF
--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -1192,7 +1192,7 @@ def set_ida_struct_member_types(bs_struct: Struct):
         return False
 
     data_changed = False
-    for udt_memb in udt_data:
+    for member_index, udt_memb in enumerate(udt_data):
         if udt_memb.offset % 8 != 0:
             _l.warning(
                 f"Struct member %s of struct %s is not byte aligned! This is currently unsupported.",
@@ -1206,14 +1206,14 @@ def set_ida_struct_member_types(bs_struct: Struct):
         if bs_member is None:
             continue
 
-        tif = convert_type_str_to_ida_type(bs_member.type)
-        if tif is None:
+        member_tif = convert_type_str_to_ida_type(bs_member.type)
+        if member_tif is None:
             _l.warning(f"Failed to convert type %s for struct member %s", bs_member.type, bs_member.name)
             continue
 
-        # TODO: investigate why this does not always work
-        udt_memb.type = tif
-        data_changed |= True
+        if member_tif != udt_memb.type:
+            struct_tif.set_udm_type(member_index, member_tif)
+            data_changed |= True
 
     return data_changed
 


### PR DESCRIPTION
After searching for quite some time how to use the `ida_typeinfo` API to set a member's type, I finally found the `set_udm_type` method, and it seems to work for my simple use cases (replacing member types by others that have the same size, e.g. `int`->`unsigned int`).

However, you might want to check at least 2 things before merging this:
-  [The `set_udm_type` function](https://cpp.docs.hex-rays.com/classtinfo__t.html#ae99be8a58d89ccf8b3d1855abe5fe190) takes optional flags [defined here](https://cpp.docs.hex-rays.com/group___e_t_f__.html#ga0114c4c184131e63b9ad095c72989eb4) ; maybe the `ETF_MAY_DESTROY` flag could be of use (I don't know `libbs` well enough yet to be sure), as it destroys overlapping members if a member is set to a bigger type. But in that case, the current implementation would quickly become buggy, as the `set_udm_type` **uses the member's index (and not its offset)...**
   - Looking again carefully at the code, it would seems that the structure is always pre-created by `compat.set_ida_struct` with correctly-sized members thanks to `idc.add_struc_member`. So I guess we should not use `ETF_MAY_DESTROY`, and that my implementation should always work
- I put the `data_changed |= True` under the condition that the new type and the old are indeed different: is this OK? I am not sure of the expected semantics of `set_ida_struct_member_types`'s return value.

Cheers

PS: IDA's Python API is so complex to use...