### PR TITLE
Added missing tif.get_type_name() on struct/enum change

### DIFF
--- a/libbs/decompilers/ida/hooks.py
+++ b/libbs/decompilers/ida/hooks.py
@@ -174,10 +174,12 @@ class IDBHooks(ida_idp.IDB_Hooks):
         elif tif.is_struct():
             bs_struct = compat.bs_struct_from_tif(tif)
             self.interface.struct_changed(bs_struct)
+            name = tif.get_type_name()
             new_type_type = Struct
         elif tif.is_enum():
             bs_enum = compat.enum_from_tif(tif)
             self.interface.enum_changed(bs_enum)
+            name = tif.get_type_name()
             new_type_type = Enum
 
         self.interface.cached_ord_to_type_names[ordinal] = (name, new_type_type)


### PR DESCRIPTION
This fixes a problem in `hooks.local_types_changed`.

https://github.com/binsync/libbs/blob/e25ae7ec1ad8c2cd20f4ca14d3024249b67a90c9/libbs/decompilers/ida/hooks.py#L169-L184

When a struct or enum is modified, `compat.typedef_info` returns `(False, None, None)`, so `name` is set to `None`.
Later, the type cache is updated using `name=None` (`self.interface.cached_ord_to_type_names[ordinal] = (name, new_type_type)`), causing major errors later on in the same function:

https://github.com/binsync/libbs/blob/e25ae7ec1ad8c2cd20f4ca14d3024249b67a90c9/libbs/decompilers/ida/hooks.py#L159-L163