### PR TITLE
Added "Jump to type" feature for IDA

### DIFF
--- a/libbs/api/decompiler_interface.py
+++ b/libbs/api/decompiler_interface.py
@@ -185,6 +185,14 @@ class DecompilerInterface:
         """
         raise NotImplementedError
 
+    def gui_show_type(self, type_name: str) -> None:
+        """
+        Relocates decompiler display to type definition
+
+        Does nothing if not implemented in a subclass
+        """
+        pass
+
     def gui_register_ctx_menu(self, name, action_string, callback_func, category=None) -> bool:
         raise NotImplementedError
 

--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -1583,6 +1583,20 @@ def jumpto(addr):
 
 
 @execute_write
+def jumpto_type(type_name: str) -> None:
+    """
+    Changes the view to the Local Types window, focusing on the specified type.
+    Does nothing if type is not found
+
+    @param type_name: Name of the user-defined type to jump to
+    @return:
+    """
+    tif = convert_type_str_to_ida_type(type_name)
+    if tif is not None:
+        ida_kernwin.open_loctypes_window(tif.get_ordinal())
+
+
+@execute_write
 def xrefs_to(addr):
     return list(idautils.XrefsTo(addr))
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -248,6 +248,9 @@ class IDAInterface(DecompilerInterface):
         func_addr = self.art_lifter.lower_addr(func_addr)
         compat.jumpto(func_addr)
 
+    def gui_show_type(self, type_name: str) -> None:
+        compat.jumpto_type(type_name)
+
     def should_watch_artifacts(self) -> bool:
         # never do hooks while IDA is in initial startup phase
         if not self._ida_analysis_finished:


### PR DESCRIPTION
As mentioned [here](https://github.com/binsync/binsync/issues/403), this implements the "jump to type" feature on IDA (defaults to a "NOP" implementation on other decompilers for now, see `decompiler_interface.gui_show_type`)