### PR TITLE
ida_kernwin.IWID_DISASMS -> ida_kernwin.IWID_DISASM

### DIFF
--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -343,7 +343,7 @@ def get_func_size(ea):
 @execute_write
 def set_ida_func_name(func_addr, new_name):
     idaapi.set_name(func_addr, new_name, idaapi.SN_FORCE)
-    ida_kernwin.request_refresh(ida_kernwin.IWID_DISASMS)
+    ida_kernwin.request_refresh(ida_kernwin.IWID_DISASM)
     # XXX: why was this here?!?!?
     #ida_kernwin.request_refresh(ida_kernwin.IWID_STRUCTS)
     ida_kernwin.request_refresh(ida_kernwin.IWID_STKVIEW)


### PR DESCRIPTION
`ida_kernwin.IWID_DISASMS` and `ida_kernwin.IWID_DISASM` variables co-lived before 9.0, for backward compatibility reasons. From IDA 9.0, Hex-Rays definitely removed the `ida_kernwin.IWID_DISASMS` variable
See https://python.docs.hex-rays.com/ida_kernwin#iwid_disasm and https://python.docs.hex-rays.com/ida_kernwin#iwid_disasms