### PR TITLE
Bump to Ghidra 11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ you must do `libbs --install` after pip install**. This will copy the appropriat
 - IDA Pro: **>= 8.4** (if you have an older version, use `v1.26.0`)
 - Binary Ninja: **>= 2.4**
 - angr-management: **>= 9.0**
-- Ghidra: **>= 11.1**
+- Ghidra: **>= 11.2**
 
 ## Usage
 LibBS exposes all decompiler API through the abstract class `DecompilerInterface`. The `DecompilerInterface` 


### PR DESCRIPTION
## Background

A bug was reported for libbs on `Ghidra 11.1` where we get data like the following:

```python
{
        '-0x118': {
          last_change: null,
          offset: -280,
          name: 'auStack_118',
          type: 'char[16]',
          size: 16,
          addr: 7888,
        },
        '-0x108': {
          last_change: null,
          offset: -264,
          name: 'auStack_108',
          type: 'char[7]',
          size: 56,
          addr: 7888,
        }
}
```

The last stack var size is in bits.

## Solution

After investigation, it seems this is no longer a bug on 11.2. As such, we are bumping our minimum supported version to 11.2. 