### PR TITLE
Add a temporary fix for #97 in IDA

### DIFF
--- a/libbs/__init__.py
+++ b/libbs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.13.0"
+__version__ = "2.13.1"
 
 
 import logging

--- a/libbs/decompilers/ida/artifact_lifter.py
+++ b/libbs/decompilers/ida/artifact_lifter.py
@@ -32,8 +32,10 @@ class IDAArtifactLifter(ArtifactLifter):
         return compat.ida_to_bs_stack_offset(func_addr, offset)
 
     def lower_type(self, type_str: str) -> str:
-        # no need to lift type for IDA, since it parses normal C
-        # types by default
+        # TODO: this is a hack until https://github.com/binsync/libbs/issues/97 is solved
+        if "/" in type_str:
+            type_str = type_str.split("/")[-1]
+
         return type_str
 
     def lower_stack_offset(self, offset: int, func_addr: int) -> int:

--- a/libbs/decompilers/ida/compat.py
+++ b/libbs/decompilers/ida/compat.py
@@ -1492,10 +1492,14 @@ def make_typedef_tif(name, type_str):
 def set_typedef(bs_typedef: Typedef):
     type_tif = convert_type_str_to_ida_type(bs_typedef.type)
     if type_tif is None:
-        _l.critical(f"Attempted to set a typedef with an invalid type: {bs_typedef.type} (does not exist)")
+        _l.critical(f"Attempted to set a typedef with an invalid type: %s (does not exist)", bs_typedef.name)
         return False
 
     typedef_tif = make_typedef_tif(bs_typedef.name, bs_typedef.type)
+    if typedef_tif is None:
+        _l.critical(f"Failed to create a typedef name=%s type=%s", bs_typedef.name, bs_typedef.type)
+        return False
+
     typedef_tif.set_named_type(idaapi.get_idati(), bs_typedef.name, ida_typeinf.NTF_TYPE)
     return True
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -199,7 +199,7 @@ class IDAInterface(DecompilerInterface):
         lowered_addr = self.art_lifter.lower_addr(func_addr)
         lowered_func = compat.fast_get_function(lowered_addr, get_rtype=False)
         if lowered_func is None:
-            _l.error(f"Function does not exist at {lowered_addr}")
+            #_l.error(f"Function does not exist at {lowered_addr}")
             return None
 
         return self.art_lifter.lift(lowered_func)


### PR DESCRIPTION
This is a temporary fix for #97. In IDA, if you get a Ghidra type that is something like `types.h/__off64t`, and attempt to set it in IDA, that type set fails. It's because we don't support scopes yet. 