### PR TITLE
[Feat]: Support Segment Syncing (IDA first)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+LibBS is a unified decompiler API that provides an abstracted interface for working with multiple decompilers (IDA Pro, Binary Ninja, Ghidra, angr-management). It enables writing plugins and scripts that work across all supported decompilers with minimal changes.
+
+## Development Commands
+
+### Installation and Setup
+```bash
+# Install libbs in development mode
+pip install -e .
+
+# Install libbs plugins to decompilers (required after pip install)
+libbs --install
+
+# Install to specific decompiler
+libbs --single-decompiler-install ida /path/to/ida
+```
+
+### Testing
+```bash
+# Run tests with pytest
+pytest tests/
+
+# Run specific test files
+pytest tests/test_artifacts.py
+pytest tests/test_decompilers.py
+pytest tests/test_cli.py
+pytest tests/test_remote_ghidra.py
+```
+
+### Project Management
+```bash
+# Build the package
+python -m build
+
+# Install test dependencies
+pip install -e ".[test]"
+
+# Install ghidra dependencies  
+pip install -e ".[ghidra]"
+```
+
+## Architecture
+
+### Core Components
+
+**DecompilerInterface** (`libbs/api/decompiler_interface.py`): The main abstraction layer that provides unified access to different decompilers. Can operate in GUI mode (default) or headless mode.
+
+**ArtifactLifter** (`libbs/api/artifact_lifter.py`): Handles conversion between decompiler-specific objects and LibBS artifacts.
+
+**Artifacts** (`libbs/artifacts/`): Unified data structures representing decompiler concepts:
+- `Function`, `FunctionHeader`, `FunctionArgument`
+- `StackVariable`, `GlobalVariable` 
+- `Struct`, `StructMember`, `Enum`, `Typedef`
+- `Comment`, `Patch`, `Context`, `Decompilation`
+
+**Decompiler Implementations** (`libbs/decompilers/`):
+- `ida/`: IDA Pro integration
+- `binja/`: Binary Ninja integration  
+- `ghidra/`: Ghidra integration (with bridge support)
+- `angr/`: angr-management integration
+
+### Plugin System
+
+**Decompiler Stubs** (`libbs/decompiler_stubs/`): Plugin entry points for each decompiler that bootstrap LibBS functionality.
+
+**Plugin Installer** (`libbs/plugin_installer.py`): Automatically installs LibBS plugins to detected decompiler installations.
+
+### Key Design Patterns
+
+**Artifact Dictionary Access**: Artifacts use a lazy-loading pattern where `.items()`, `.keys()`, `.values()` return "light" objects, but `dict[key]` returns full objects (which may trigger decompilation).
+
+**Decompiler Discovery**: Use `DecompilerInterface.discover()` to auto-detect the current decompiler environment.
+
+**Serialization**: All artifacts support JSON/TOML serialization via `.dumps()` and `.loads()` methods.
+
+## Development Guidelines
+
+### Adding New Decompiler Support
+1. Create new directory in `libbs/decompilers/`
+2. Implement `interface.py` inheriting from `DecompilerInterface`
+3. Implement `artifact_lifter.py` inheriting from `ArtifactLifter` 
+4. Add decompiler stub in `libbs/decompiler_stubs/`
+5. Update `SUPPORTED_DECOMPILERS` constant
+
+### Working with Artifacts
+- Always use `deci.functions[addr]` to get full Function objects
+- Use `for addr, light_func in deci.functions.items()` for iteration
+- Test serialization with both JSON and TOML formats
+- Validate artifacts work across all supported decompilers
+
+### Testing Strategy
+- Unit tests for artifacts (`test_artifacts.py`)
+- Integration tests for decompiler interfaces (`test_decompilers.py`) 
+- CLI testing (`test_cli.py`)
+- Remote Ghidra functionality (`test_remote_ghidra.py`)
+
+### Environment Variables
+- `GHIDRA_HEADLESS_PATH`: Path to Ghidra headless binary for headless mode

--- a/libbs/__init__.py
+++ b/libbs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.15.6"
+__version__ = "2.16.0"
 
 
 import logging

--- a/libbs/api/artifact_dict.py
+++ b/libbs/api/artifact_dict.py
@@ -3,7 +3,7 @@ import logging
 
 from libbs.artifacts import (
     Artifact, Comment, Enum, FunctionHeader, Function, FunctionArgument,
-    GlobalVariable, Patch, StackVariable, Struct, StructMember, Typedef
+    GlobalVariable, Patch, Segment, StackVariable, Struct, StructMember, Typedef
 )
 
 if typing.TYPE_CHECKING:
@@ -47,7 +47,8 @@ class ArtifactDict(dict):
             Enum: (self._deci._set_enum, self._deci._get_enum, self._deci._enums, self._deci._del_enum),
             Typedef: (self._deci._set_typedef, self._deci._get_typedef, self._deci._typedefs, self._deci._del_typedef),
             Comment: (self._deci._set_comment, self._deci._get_comment, self._deci._comments, self._deci._del_comment),
-            Patch: (self._deci._set_patch, self._deci._get_patch, self._deci._patches, self._deci._del_patch)
+            Patch: (self._deci._set_patch, self._deci._get_patch, self._deci._patches, self._deci._del_patch),
+            Segment: (self._deci._set_segment, self._deci._get_segment, self._deci._segments, self._deci._del_segment)
         }
 
         functions = self._art_function.get(artifact_cls, None)
@@ -125,6 +126,8 @@ class ArtifactDict(dict):
         if isinstance(art, Struct):
             self._artifact_remover(key)
             self._deci.struct_changed(art, deleted=True)
+        else:
+            self._artifact_remover(key)
 
     def __iter__(self):
         return iter(self._lifted_art_lister())

--- a/libbs/artifacts/__init__.py
+++ b/libbs/artifacts/__init__.py
@@ -10,6 +10,7 @@ from .enum import Enum
 from .func import Function, FunctionHeader, FunctionArgument
 from .global_variable import GlobalVariable
 from .patch import Patch
+from .segment import Segment
 from .stack_variable import StackVariable
 from .struct import Struct, StructMember
 from .context import Context
@@ -29,6 +30,7 @@ ART_NAME_TO_CLS = {
     Decompilation.__name__: Decompilation,
     Context.__name__: Context,
     Typedef.__name__: Typedef,
+    Segment.__name__: Segment,
 }
 
 ALL_ARTIFACTS = list(ART_NAME_TO_CLS.values())

--- a/libbs/artifacts/segment.py
+++ b/libbs/artifacts/segment.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from .artifact import Artifact
+
+
+class Segment(Artifact):
+    __slots__ = Artifact.__slots__ + (
+        "name",
+        "start_addr", 
+        "end_addr",
+        "permissions"
+    )
+
+    def __init__(
+        self,
+        name: str = None,
+        start_addr: int = None,
+        end_addr: int = None,
+        permissions: Optional[str] = None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.name = name
+        self.start_addr = start_addr
+        self.end_addr = end_addr
+        self.permissions = permissions
+
+    def __str__(self):
+        perms_str = f" [{self.permissions}]" if self.permissions else ""
+        return f"<Segment: {self.name} {hex(self.start_addr) if self.start_addr else '?'}-{hex(self.end_addr) if self.end_addr else '?'}{perms_str}>"
+
+    @property
+    def size(self) -> Optional[int]:
+        """Returns the size of the segment in bytes."""
+        if self.start_addr is not None and self.end_addr is not None:
+            return self.end_addr - self.start_addr
+        return None

--- a/libbs/decompilers/ida/artifact_lifter.py
+++ b/libbs/decompilers/ida/artifact_lifter.py
@@ -1,6 +1,7 @@
 import logging
 
 from libbs.api import ArtifactLifter
+from libbs.artifacts import Segment
 
 l = logging.getLogger(name=__name__)
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -6,7 +6,7 @@ import libbs
 from libbs.api.decompiler_interface import DecompilerInterface
 from libbs.artifacts import (
     StackVariable, Function, FunctionHeader, Struct, Comment, GlobalVariable, Enum, Patch, Artifact, Decompilation,
-    Context, Typedef
+    Context, Typedef, Segment
 )
 from libbs.api.decompiler_interface import requires_decompilation
 from . import compat
@@ -430,6 +430,19 @@ class IDAInterface(DecompilerInterface):
     def _comments(self) -> Dict[int, Comment]:
         # TODO: implement me!
         return {}
+
+    # segments
+    def _set_segment(self, segment: Segment, **kwargs) -> bool:
+        return compat.set_segment(segment)
+
+    def _get_segment(self, name) -> Optional[Segment]:
+        return compat.segment(name)
+
+    def _del_segment(self, name) -> bool:
+        return compat.del_segment(name)
+
+    def _segments(self) -> Dict[str, Segment]:
+        return compat.segments()
 
     # others...
     def _set_function_header(self, fheader: FunctionHeader, **kwargs) -> bool:


### PR DESCRIPTION
`Segment`s (memory spaces with names and permissions) can now be accessed, edited, and deleted through the `DecompilerInterface` API. This PR adds support to the abstract interfaces and also the backend for IDA API. 

Note for devs: Claude Code wrote a lot of the IDA side API calls, and it worked. Checked by me and tested in the new testcase. 