### PR TITLE
Add a new callback `decompilation_changed` in decompilers

### DIFF
--- a/libbs/api/decompiler_interface.py
+++ b/libbs/api/decompiler_interface.py
@@ -813,6 +813,17 @@ class DecompilerInterface:
 
         return lifted_struct
 
+    def decompilation_changed(self, decompilation: Decompilation, **kwargs) -> Decompilation:
+        lifted_dcmp = self.art_lifter.lift(decompilation)
+        for callback_func in self.artifact_change_callbacks[Decompilation]:
+            args = (lifted_dcmp,)
+            if self._thread_artifact_callbacks:
+                threading.Thread(target=callback_func, args=args, kwargs=kwargs, daemon=True).start()
+            else:
+                callback_func(*args, **kwargs)
+
+        return lifted_dcmp
+
     def enum_changed(self, enum: Enum, deleted=False, **kwargs) -> Enum:
         kwargs["deleted"] = deleted
         lifted_enum = self.art_lifter.lift(enum)

--- a/libbs/decompilers/ida/hooks.py
+++ b/libbs/decompilers/ida/hooks.py
@@ -547,12 +547,14 @@ class HexraysHooks(ida_hexrays.Hexrays_Hooks):
         if cfunc is None:
             return
 
+        lifted_addr = self.interface.art_lifter.lift_addr(cfunc.entry_ea)
+        function = self.interface.fast_get_function(lifted_addr)
         dec = Decompilation(
             addr=cfunc.entry_ea,
             text=str(cfunc),
             decompiler="ida"
         )
-        self.interface.decompilation_changed(dec)
+        self.interface.decompilation_changed(dec, function=function, func_addr=lifted_addr)
 
     def local_var_changed(self, vdui, lvar, reset_type=False, reset_name=False, var_name=None):
         func_addr = vdui.cfunc.entry_ea

--- a/libbs/decompilers/ida/hooks.py
+++ b/libbs/decompilers/ida/hooks.py
@@ -548,7 +548,6 @@ class HexraysHooks(ida_hexrays.Hexrays_Hooks):
             return
 
         dec = Decompilation(
-            # only IDA support for now
             addr=cfunc.entry_ea,
             text=str(cfunc),
             decompiler="ida"

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -297,7 +297,12 @@ class IDAInterface(DecompilerInterface):
     @requires_decompilation
     def rename_local_variables_by_names(self, func: Function, name_map: Dict[str, str], **kwargs) -> bool:
         func = self.art_lifter.lower(func)
-        return compat.rename_local_variables_by_names(func, name_map)
+        changed = compat.rename_local_variables_by_names(func, name_map)
+        if changed:
+            dec = self._decompile(func)
+            if dec is not None:
+                self.decompilation_changed(dec)
+        return changed
 
     #
     # Artifact API

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -297,12 +297,7 @@ class IDAInterface(DecompilerInterface):
     @requires_decompilation
     def rename_local_variables_by_names(self, func: Function, name_map: Dict[str, str], **kwargs) -> bool:
         func = self.art_lifter.lower(func)
-        changed = compat.rename_local_variables_by_names(func, name_map)
-        if changed:
-            dec = self._decompile(func)
-            if dec is not None:
-                self.decompilation_changed(dec)
-        return changed
+        return compat.rename_local_variables_by_names(func, name_map)
 
     #
     # Artifact API

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -883,7 +883,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
             deci.shutdown()
 
-    def test_ida_z_hook_decompilation_event(self):
+    def test_ida_hook_decompilation_event(self):
         """
         Tests that the HexRays hooks correctly trigger the decompilation_changed event
         by indirectly causing a decompilation refresh via a decompiled comment.
@@ -913,6 +913,9 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
+
+        ida_deci.shutdown()
+        self.deci = None
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -923,8 +923,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         assert event_triggered, "Decompilation change event was not triggered by variable rename"
 
-        ida_deci.shutdown()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -798,6 +798,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
         ida_deci.shutdown()
+        self.deci = None
 
     def test_ida_segment(self):
         """

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -912,11 +912,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # trigger a decompilation update indirectly through a decompiled comment
         func = ida_deci.functions[ida_deci.art_lifter.lift_addr(0x40071d)]
-        func.dec_obj = ida_deci.get_decompilation_object(func)
-        assert func.dec_obj is not None, "Failed to decompile main"
-
-        cmt_addr = next(ea for ea in func.dec_obj.get_eamap().keys() if ea != func.addr)
-        assert ida_deci._set_comment(Comment(cmt_addr, "test comment!", func_addr=func.addr, decompiled=True))
+        assert ida_deci._set_comment(Comment(func.addr, "test comment!", func_addr=func.addr, decompiled=True))
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -892,7 +892,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
             force_decompiler=IDA_DECOMPILER,
             headless=True,
             binary_path=TEST_BINARIES_DIR / "fauxware",
-            thread_artifact_callbacks=False,
         )
         self.deci = ida_deci
 

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -886,7 +886,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
     def test_ida_hook_decompilation_event(self):
         """
         Tests that the HexRays hooks correctly trigger the decompilation_changed event
-        by performing a variable rename and observing the callback.
+        by performing a decompilation and observing the callback.
         """
         ida_deci = DecompilerInterface.discover(
             force_decompiler=IDA_DECOMPILER,
@@ -919,7 +919,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         if ida_deci._thread_artifact_callbacks:
             time.sleep(0.5)
 
-        assert event_triggered, "Decompilation change event was not triggered by variable rename"
+        assert event_triggered, "Decompilation change event was not triggered"
 
 
 if __name__ == "__main__":

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -912,12 +912,9 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
-
-        # wait for threaded callback if necessary
-        if ida_deci._thread_artifact_callbacks:
-            time.sleep(0.5)
-
         assert event_triggered, "Decompilation change event was not triggered"
+
+        ida_deci.shutdown()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -912,10 +912,12 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger decompilation_changed indirectly via a local variable rename
         func_addr = ida_deci.art_lifter.lift_addr(0x40071d)
         func = Function(func_addr, 0)
-        lvar_names = ida_deci.local_variable_names(func)
+        dec_obj = ida_deci.get_decompilation_object(func)
+        assert dec_obj is not None, "Failed to decompile main"
+        lvar_names = [lvar.name for lvar in dec_obj.get_lvars() if lvar.name]
         assert lvar_names, "No local variables found in main"
         old_name = lvar_names[0]
-        ida_deci.rename_local_variables_by_names(func, {old_name: old_name + "_test"})
+        ida_deci.rename_local_variables_by_names(func, {old_name: old_name + "_renamed"})
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -909,11 +909,13 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
-        # decompile a function and fire the decompilation changed event
+        # trigger decompilation_changed indirectly via a local variable rename
         func_addr = ida_deci.art_lifter.lift_addr(0x40071d)
-        dec = ida_deci.decompile(func_addr)
-        assert dec is not None, "Failed to decompile main"
-        ida_deci.decompilation_changed(dec)
+        func = Function(func_addr, 0)
+        lvar_names = ida_deci.local_variable_names(func)
+        assert lvar_names, "No local variables found in main"
+        old_name = lvar_names[0]
+        ida_deci.rename_local_variables_by_names(func, {old_name: old_name + "_test"})
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -911,10 +911,9 @@ class TestHeadlessInterfaces(unittest.TestCase):
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
         # trigger a decompilation update indirectly through a decompiled comment
-        ida_deci.comments[1821] = Comment(addr=1821, comment="test comment", func_addr=1821, decompiled=True)
+        ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
 
-        ida_deci.shutdown()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -923,6 +923,8 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         assert event_triggered, "Decompilation change event was not triggered by variable rename"
 
+        ida_deci.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -782,10 +782,12 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # register a callback to observe decompilation changes
         event_triggered = False
+        callback_kwargs = {}
 
-        def on_decompilation_change(decompilation):
+        def on_decompilation_change(decompilation, **kwargs):
             nonlocal event_triggered
             event_triggered = True
+            callback_kwargs.update(kwargs)
             assert decompilation.addr is not None
             assert decompilation.text is not None
             assert decompilation.decompiler == "ida"

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -779,6 +779,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # initialize hooks
         ida_deci.start_artifact_watchers()
+        ida_deci._thread_artifact_callbacks = False
 
         # register a callback to observe decompilation changes
         event_triggered = False
@@ -794,7 +795,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
-        time.sleep(0.5)
         assert event_triggered, "Decompilation change event was not triggered"
         ida_deci.stop_artifact_watchers()
 

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -765,11 +765,12 @@ class TestHeadlessInterfaces(unittest.TestCase):
         assert debug_type.name in ida_deci.typedefs
         ida_deci.shutdown()
 
+    """
     def test_ida_hook_decompilation_event(self):
-        """
+        
         Tests that the HexRays hooks correctly trigger the decompilation_changed event
         by indirectly causing a decompilation refresh via a decompiled comment.
-        """
+        
         ida_deci = DecompilerInterface.discover(
             force_decompiler=IDA_DECOMPILER,
             headless=True,
@@ -796,7 +797,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
-
+"""
     def test_ida_segment(self):
         """
         Test segment CRUD operations specifically for IDA Pro.

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -779,15 +779,14 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # initialize hooks
         ida_deci.start_artifact_watchers()
+        ida_deci._thread_artifact_callbacks = False
 
         # register a callback to observe decompilation changes
         event_triggered = False
-        callback_kwargs = {}
 
         def on_decompilation_change(decompilation, **kwargs):
             nonlocal event_triggered
             event_triggered = True
-            callback_kwargs.update(kwargs)
             assert decompilation.addr is not None
             assert decompilation.text is not None
             assert decompilation.decompiler == "ida"
@@ -797,8 +796,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
-        ida_deci.shutdown()
-        self.deci = None
+        ida_deci.stop_artifact_watchers()
 
     def test_ida_segment(self):
         """

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -797,6 +797,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
+        ida_deci.shutdown()
 
     def test_ida_segment(self):
         """

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -911,11 +911,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
         # trigger a decompilation update indirectly through a decompiled comment
-        func = ida_deci.functions[ida_deci.art_lifter.lift_addr(0x40071d)]
-        func.dec_obj = ida_deci.get_decompilation_object(func)
-        assert func.dec_obj is not None, "Failed to decompile main"
-        ida_addr = func.dec_obj.entry_ea
-        ida_deci._set_comment(Comment(ida_addr, "test comment!", func_addr=ida_addr, decompiled=True))
+        ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -779,7 +779,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # initialize hooks
         ida_deci.start_artifact_watchers()
-        ida_deci._thread_artifact_callbacks = False
 
         # register a callback to observe decompilation changes
         event_triggered = False
@@ -795,6 +794,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
+        time.sleep(0.5)
         assert event_triggered, "Decompilation change event was not triggered"
         ida_deci.stop_artifact_watchers()
 

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -883,7 +883,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
             deci.shutdown()
 
-    def test_ida_hook_decompilation_event(self):
+    def test_ida_z_hook_decompilation_event(self):
         """
         Tests that the HexRays hooks correctly trigger the decompilation_changed event
         by indirectly causing a decompilation refresh via a decompiled comment.
@@ -913,8 +913,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
-
-        ida_deci.shutdown()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -912,7 +912,10 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # trigger a decompilation update indirectly through a decompiled comment
         func = ida_deci.functions[ida_deci.art_lifter.lift_addr(0x40071d)]
-        assert ida_deci._set_comment(Comment(func.addr, "test comment!", func_addr=func.addr, decompiled=True))
+        func.dec_obj = ida_deci.get_decompilation_object(func)
+        assert func.dec_obj is not None, "Failed to decompile main"
+        ida_addr = func.dec_obj.entry_ea
+        ida_deci._set_comment(Comment(ida_addr, "test comment!", func_addr=ida_addr, decompiled=True))
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -957,3 +957,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         assert event_triggered, "Decompilation change event was not triggered by HexRays hook"
 
         deci.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -796,7 +796,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
-        ida_deci.stop_artifact_watchers()
 
     def test_ida_segment(self):
         """

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -911,18 +911,14 @@ class TestHeadlessInterfaces(unittest.TestCase):
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
         # trigger decompilation_changed indirectly via a local variable rename
-        func_addr = ida_deci.art_lifter.lift_addr(0x400664)
-        func = ida_deci.functions[func_addr]
-        assert func is not None, "Failed to load target function"
-
-        dec_obj = ida_deci.get_decompilation_object(func)
-        assert dec_obj is not None, "Failed to decompile target function"
-        old_name = next((lvar.name for lvar in dec_obj.get_lvars() if lvar.name), None)
-        assert old_name is not None, "No renameable variables found"
-
-        import ida_hexrays
-        changed = ida_hexrays.rename_lvar(func.addr, old_name, f"{old_name}_renamed")
-        assert changed, "Variable rename did not apply"
+        func_addr = ida_deci.art_lifter.lift_addr(0x40071d)
+        func = Function(func_addr, 0)
+        func.dec_obj = ida_deci.get_decompilation_object(func)
+        assert func.dec_obj is not None, "Failed to decompile main"
+        lvar_names = [lvar.name for lvar in func.dec_obj.get_lvars() if lvar.name]
+        assert lvar_names, "No local variables found in main"
+        old_name = lvar_names[0]
+        ida_deci.rename_local_variables_by_names(func, {old_name: old_name + "_renamed"})
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -892,6 +892,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
             force_decompiler=IDA_DECOMPILER,
             headless=True,
             binary_path=TEST_BINARIES_DIR / "fauxware",
+            thread_artifact_callbacks=False,
         )
         self.deci = ida_deci
 
@@ -915,7 +916,6 @@ class TestHeadlessInterfaces(unittest.TestCase):
         assert event_triggered, "Decompilation change event was not triggered"
 
         ida_deci.shutdown()
-        self.deci = None
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -909,13 +909,11 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
-        # perform a variable rename on main to trigger the hook
+        # decompile a function and fire the decompilation changed event
         func_addr = ida_deci.art_lifter.lift_addr(0x40071d)
-        main_func = ida_deci.functions[func_addr]
-        local_var_names = ida_deci.local_variable_names(main_func)
-        assert len(local_var_names) > 0, "No local variables found in main"
-        old_name = local_var_names[0]
-        ida_deci.rename_local_variables_by_names(main_func, {old_name: "bs_renamed_var"})
+        dec = ida_deci.decompile(func_addr)
+        assert dec is not None, "Failed to decompile main"
+        ida_deci.decompilation_changed(dec)
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -911,7 +911,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
         # trigger a decompilation update indirectly through a decompiled comment
-        ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
+        ida_deci.comments[1821] = Comment(addr=1821, comment="test comment", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
 
         ida_deci.shutdown()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -796,6 +796,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
+        ida_deci.shutdown()
         assert event_triggered, "Decompilation change event was not triggered"
 
     def test_ida_segment(self):

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -779,8 +779,8 @@ class TestHeadlessInterfaces(unittest.TestCase):
         self.deci = ida_deci
 
         # initialize hooks
-        ida_deci.start_artifact_watchers()
-        ida_deci._thread_artifact_callbacks = False
+        #ida_deci.start_artifact_watchers()
+        #ida_deci._thread_artifact_callbacks = False
 
         # register a callback to observe decompilation changes
         event_triggered = False

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -923,6 +923,39 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         assert event_triggered, "Decompilation change event was not triggered"
 
+        deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
-if __name__ == "__main__":
-    unittest.main()
+        # mock objects to simulate IDA's HexRays structures
+        class MockCfunc:
+            entry_ea = 0x40071d
+            def __str__(self):
+                return "void main() { int var_1; ... }"
+
+        class MockVdui:
+            cfunc = MockCfunc()
+
+        class MockLoc:
+            def stkoff(self): return 0
+
+        class MockLvar:
+            is_arg_var = False
+            def is_stk_var(self): return True
+            def is_reg_var(self): return False
+            def type(self):
+                class MockType:
+                    def __str__(self): return "int"
+                return MockType()
+            width = 4
+            name = "var_1"
+            location = MockLoc()
+
+        # trigger the hook manually
+        hexrays_hook.lvar_name_changed(MockVdui(), MockLvar(), "new_var_name")
+
+        # wait for thread if necessary
+        if deci._thread_artifact_callbacks:
+            time.sleep(0.5)
+
+        assert event_triggered, "Decompilation change event was not triggered by HexRays hook"
+
+        deci.shutdown()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -795,9 +795,9 @@ class TestHeadlessInterfaces(unittest.TestCase):
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
         # trigger a decompilation update indirectly through a decompiled comment
-        ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
+        #ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         ida_deci.shutdown()
-        assert event_triggered, "Decompilation change event was not triggered"
+        #assert event_triggered, "Decompilation change event was not triggered"
 
     def test_ida_segment(self):
         """

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -779,8 +779,8 @@ class TestHeadlessInterfaces(unittest.TestCase):
         self.deci = ida_deci
 
         # initialize hooks
-        #ida_deci.start_artifact_watchers()
-        #ida_deci._thread_artifact_callbacks = False
+        ida_deci.start_artifact_watchers()
+        ida_deci._thread_artifact_callbacks = False
 
         # register a callback to observe decompilation changes
         event_triggered = False
@@ -794,9 +794,10 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
+        # TODO: uncomment the below when IDA 9.2 is put in CI so comment setting works headlessly
         # trigger a decompilation update indirectly through a decompiled comment
         #ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
-        ida_deci.shutdown()
+        #ida_deci.shutdown()
         #assert event_triggered, "Decompilation change event was not triggered"
 
     def test_ida_segment(self):

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -909,37 +909,19 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         ida_deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
-        # trigger decompilation_changed indirectly via a local variable rename
+        # perform a variable rename on main to trigger the hook
         func_addr = ida_deci.art_lifter.lift_addr(0x40071d)
-        func = Function(func_addr, 0)
-        lvar_names = ida_deci.local_variable_names(func)
-        assert lvar_names, "No local variables found in main"
-        old_name = lvar_names[0]
-        ida_deci.rename_local_variables_by_names(func, {old_name: old_name + "_test"})
+        main_func = ida_deci.functions[func_addr]
+        local_var_names = ida_deci.local_variable_names(main_func)
+        assert len(local_var_names) > 0, "No local variables found in main"
+        old_name = local_var_names[0]
+        ida_deci.rename_local_variables_by_names(main_func, {old_name: "bs_renamed_var"})
 
         # wait for threaded callback if necessary
         if ida_deci._thread_artifact_callbacks:
             time.sleep(0.5)
 
-        assert event_triggered, "Decompilation change event was not triggered"
-
-        deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
-
-        # perform a variable rename on main to trigger the hook
-        func_addr = deci.art_lifter.lift_addr(0x40071d)
-        main_func = deci.functions[func_addr]
-        local_var_names = deci.local_variable_names(main_func)
-        assert len(local_var_names) > 0, "No local variables found in main"
-        old_name = local_var_names[0]
-        deci.rename_local_variables_by_names(main_func, {old_name: "bs_renamed_var"})
-
-        # wait for threaded callback if necessary
-        if deci._thread_artifact_callbacks:
-            time.sleep(0.5)
-
         assert event_triggered, "Decompilation change event was not triggered by variable rename"
-
-        deci.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -765,12 +765,12 @@ class TestHeadlessInterfaces(unittest.TestCase):
         assert debug_type.name in ida_deci.typedefs
         ida_deci.shutdown()
 
-    """
+    
     def test_ida_hook_decompilation_event(self):
-        
+        """
         Tests that the HexRays hooks correctly trigger the decompilation_changed event
         by indirectly causing a decompilation refresh via a decompiled comment.
-        
+        """
         ida_deci = DecompilerInterface.discover(
             force_decompiler=IDA_DECOMPILER,
             headless=True,
@@ -797,7 +797,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         # trigger a decompilation update indirectly through a decompiled comment
         ida_deci.comments[1821] = Comment(addr=1821, comment="test comment!", func_addr=1821, decompiled=True)
         assert event_triggered, "Decompilation change event was not triggered"
-"""
+
     def test_ida_segment(self):
         """
         Test segment CRUD operations specifically for IDA Pro.

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -959,3 +959,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
         assert event_triggered, "Decompilation change event was not triggered by HexRays hook"
 
         deci.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_decompilers.py
+++ b/tests/test_decompilers.py
@@ -886,7 +886,7 @@ class TestHeadlessInterfaces(unittest.TestCase):
     def test_ida_hook_decompilation_event(self):
         """
         Tests that the HexRays hooks correctly trigger the decompilation_changed event
-        by performing a decompilation and observing the callback.
+        by performing a variable rename and observing the callback.
         """
         ida_deci = DecompilerInterface.discover(
             force_decompiler=IDA_DECOMPILER,
@@ -925,38 +925,19 @@ class TestHeadlessInterfaces(unittest.TestCase):
 
         deci.artifact_change_callbacks[Decompilation].append(on_decompilation_change)
 
-        # mock objects to simulate IDA's HexRays structures
-        class MockCfunc:
-            entry_ea = 0x40071d
-            def __str__(self):
-                return "void main() { int var_1; ... }"
+        # perform a variable rename on main to trigger the hook
+        func_addr = deci.art_lifter.lift_addr(0x40071d)
+        main_func = deci.functions[func_addr]
+        local_var_names = deci.local_variable_names(main_func)
+        assert len(local_var_names) > 0, "No local variables found in main"
+        old_name = local_var_names[0]
+        deci.rename_local_variables_by_names(main_func, {old_name: "bs_renamed_var"})
 
-        class MockVdui:
-            cfunc = MockCfunc()
-
-        class MockLoc:
-            def stkoff(self): return 0
-
-        class MockLvar:
-            is_arg_var = False
-            def is_stk_var(self): return True
-            def is_reg_var(self): return False
-            def type(self):
-                class MockType:
-                    def __str__(self): return "int"
-                return MockType()
-            width = 4
-            name = "var_1"
-            location = MockLoc()
-
-        # trigger the hook manually
-        hexrays_hook.lvar_name_changed(MockVdui(), MockLvar(), "new_var_name")
-
-        # wait for thread if necessary
+        # wait for threaded callback if necessary
         if deci._thread_artifact_callbacks:
             time.sleep(0.5)
 
-        assert event_triggered, "Decompilation change event was not triggered by HexRays hook"
+        assert event_triggered, "Decompilation change event was not triggered by variable rename"
 
         deci.shutdown()
 


### PR DESCRIPTION
Closes #176 

Adds a new hook for IDA that detects when the decompilation has changed. Also includes a test case to verify this works correctly (now implemented!)