### PR TITLE
Add `shortcut` parameter to `gui_register_ctx_menu`

### DIFF
--- a/libbs/__init__.py
+++ b/libbs/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.4.1"
+__version__ = "3.5.0"
 
 
 import logging

--- a/libbs/api/decompiler_interface.py
+++ b/libbs/api/decompiler_interface.py
@@ -192,7 +192,18 @@ class DecompilerInterface:
         """
         pass
 
-    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None) -> bool:
+    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None, shortcut=None) -> bool:
+        """
+        Register a context menu / plugin action.
+
+        :param name: unique identifier for the action
+        :param action_string: human-readable label shown in the menu
+        :param callback_func: function to invoke when the action fires
+        :param category: optional menu category / sub-path
+        :param shortcut: optional keyboard shortcut in Qt format (e.g. "Ctrl+Shift+D").
+            Implementations translate this to their native format. When the native
+            decompiler cannot bind a shortcut programmatically, this is a no-op.
+        """
         raise NotImplementedError
 
     def gui_ask_for_string(self, question, title="Plugin Question", default="") -> str:
@@ -253,8 +264,11 @@ class DecompilerInterface:
     def gui_register_ctx_menu_many(self, actions: dict[str, tuple[str, Callable]]):
         parsed_actions = self._parse_ctx_menu_actions(actions)
         for action in parsed_actions:
-            category, name, action_string, callback_func = action
-            self.gui_register_ctx_menu(name, action_string, callback_func, category=category)
+            category, name, action_string, callback_func = action[:4]
+            shortcut = action[4] if len(action) > 4 else None
+            self.gui_register_ctx_menu(
+                name, action_string, callback_func, category=category, shortcut=shortcut
+            )
 
     #
     # Override Mandatory API

--- a/libbs/decompilers/angr/compat.py
+++ b/libbs/decompilers/angr/compat.py
@@ -20,6 +20,8 @@ class GenericBSAngrManagementPlugin(BasePlugin):
         super().__init__(workspace)
         # (name, action_string, callback_func, category)
         self.context_menu_items = context_menu_items or []
+        # Keep strong refs to QShortcut objects so Qt doesn't GC them
+        self._qshortcuts: list = []
         if interface is None:
             from libbs.decompilers.angr.interface import AngrInterface
             self.interface = AngrInterface(
@@ -31,6 +33,34 @@ class GenericBSAngrManagementPlugin(BasePlugin):
 
     def teardown(self):
         pass
+
+    def register_shortcut(self, name: str, shortcut: str, callback_func, deci=None) -> bool:
+        """
+        Register a keyboard shortcut bound to ``callback_func`` on the angr-management
+        main window. The shortcut is an application-wide QShortcut so it fires from
+        any focused widget.
+        """
+        from PySide6.QtGui import QShortcut, QKeySequence
+        from PySide6.QtCore import Qt
+        from PySide6.QtWidgets import QApplication
+
+        parent = getattr(self.workspace, "main_window", None)
+        if parent is None:
+            app = QApplication.instance()
+            if app is not None:
+                for w in app.topLevelWidgets():
+                    if w.isWindow():
+                        parent = w
+                        break
+        if parent is None:
+            l.warning("No Qt main window available; cannot bind shortcut %s", shortcut)
+            return False
+
+        qsc = QShortcut(QKeySequence(shortcut), parent)
+        qsc.setContext(Qt.ApplicationShortcut)
+        qsc.activated.connect(lambda: callback_func(None, deci=deci))
+        self._qshortcuts.append(qsc)
+        return True
 
     #
     # Context Menus

--- a/libbs/decompilers/angr/interface.py
+++ b/libbs/decompilers/angr/interface.py
@@ -211,13 +211,19 @@ class AngrInterface(DecompilerInterface):
     def gui_goto(self, func_addr):
         self.workspace.jump_to(self.art_lifter.lower_addr(func_addr))
 
-    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None) -> bool:
+    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None, shortcut=None) -> bool:
         if self.gui_plugin is None:
             l.critical("Cannot register context menu item without a GUI plugin.")
             return False
 
         self._ctx_menu_items.append((name, action_string, callback_func, category))
         self.gui_plugin.context_menu_items = self._ctx_menu_items
+
+        if shortcut:
+            try:
+                self.gui_plugin.register_shortcut(name, shortcut, callback_func, deci=self)
+            except Exception as e:
+                l.warning("Failed to register angr shortcut %r for %s: %s", shortcut, name, e)
         return True
 
     def gui_active_context(self) -> Optional[Context]:

--- a/libbs/decompilers/binja/interface.py
+++ b/libbs/decompilers/binja/interface.py
@@ -131,7 +131,7 @@ class BinjaInterface(DecompilerInterface):
         func_addr = self.art_lifter.lower_addr(func_addr)
         self.bv.offset = func_addr
 
-    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None) -> bool:
+    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None, shortcut=None) -> bool:
         # TODO: this needs to have a wrapper function that passes the bv to the current deci
         # correct name, category, and action_string for Binja
         action_string = action_string.replace("/", "\\")
@@ -143,6 +143,19 @@ class BinjaInterface(DecompilerInterface):
             callback_func,
             is_valid=self.is_bn_func
         )
+
+        if shortcut and BN_UI_AVAILABLE:
+            try:
+                from binaryninjaui import UIAction, UIActionHandler
+                action_name = f"{category}\\{action_string}" if category else action_string
+                UIAction.registerAction(action_name, shortcut)
+                # UIAction expects a callable taking a UIActionContext
+                UIActionHandler.globalActions().bindAction(
+                    action_name, UIAction(lambda ctx: callback_func(None))
+                )
+            except Exception as e:
+                l.warning(f"Failed to register Binja shortcut {shortcut!r} for {name}: {e}")
+
         return True
 
     def gui_ask_for_string(self, question, title="Plugin Question", default="") -> str:

--- a/libbs/decompilers/ghidra/hooks.py
+++ b/libbs/decompilers/ghidra/hooks.py
@@ -239,10 +239,4 @@ def create_context_action(
             .validContextWhen(lambda ctx: ctx is not None and ctx.getAddress() is not None)
             .onAction(_invoke))
 
-    if shortcut:
-        try:
-            b = b.keyBinding(_qt_shortcut_to_ghidra(shortcut))
-        except Exception:
-            pass
-
     return b.buildAndInstall(tool)

--- a/libbs/decompilers/ghidra/hooks.py
+++ b/libbs/decompilers/ghidra/hooks.py
@@ -207,7 +207,23 @@ def create_data_monitor(deci: "GhidraDecompilerInterface"):
     return data_monitor
 
 
-def create_context_action(name, action_string, callback_func, category=None, plugin_name="libbs_ghidra", tool=None):
+def _qt_shortcut_to_ghidra(shortcut: str) -> str:
+    """Convert a Qt-style shortcut like "Ctrl+Shift+D" to Ghidra's "ctrl shift D"."""
+    if not shortcut:
+        return ""
+    parts = shortcut.split("+")
+    out = []
+    for p in parts[:-1]:
+        out.append(p.strip().lower())
+    key = parts[-1].strip()
+    out.append(key.upper() if len(key) == 1 else key)
+    return " ".join(out)
+
+
+def create_context_action(
+    name, action_string, callback_func, category=None,
+    plugin_name="libbs_ghidra", tool=None, shortcut=None,
+):
     from .compat.imports import ProgramLocationActionContext, ActionBuilder
     def _invoke(ctx: ProgramLocationActionContext):
         threading.Thread(target=callback_func, daemon=True).start()
@@ -222,5 +238,11 @@ def create_context_action(name, action_string, callback_func, category=None, plu
             .withContext(ProgramLocationActionContext)
             .validContextWhen(lambda ctx: ctx is not None and ctx.getAddress() is not None)
             .onAction(_invoke))
+
+    if shortcut:
+        try:
+            b = b.keyBinding(_qt_shortcut_to_ghidra(shortcut))
+        except Exception:
+            pass
 
     return b.buildAndInstall(tool)

--- a/libbs/decompilers/ghidra/interface.py
+++ b/libbs/decompilers/ghidra/interface.py
@@ -152,7 +152,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
         self._main_thread_queue.put((func, args, kwargs))
         return self._results_queue.get()
 
-    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None) -> bool:
+    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None, shortcut=None) -> bool:
         from .hooks import create_context_action
 
         def callback_func_wrap(*args, **kwargs):
@@ -163,7 +163,7 @@ class GhidraDecompilerInterface(DecompilerInterface):
                 raise
         create_context_action(
             name, action_string, callback_func_wrap, category=(category or "LibBS"),
-            tool=self.flat_api.getState().getTool()
+            tool=self.flat_api.getState().getTool(), shortcut=shortcut,
         )
         return True
 

--- a/libbs/decompilers/ida/interface.py
+++ b/libbs/decompilers/ida/interface.py
@@ -33,6 +33,13 @@ import ida_auto
 _l = logging.getLogger(name=__name__)
 
 
+def _qt_shortcut_to_ida(shortcut: str) -> str:
+    """Convert a Qt-style shortcut like "Ctrl+Shift+D" to IDA's "Ctrl-Shift-D"."""
+    if not shortcut:
+        return ""
+    return shortcut.replace("+", "-")
+
+
 #
 #   Controller
 #
@@ -113,12 +120,13 @@ class IDAInterface(DecompilerInterface):
     def gui_ask_for_choice(self, question: str, choices: list, title="Plugin Question") -> str:
         return ida_ui.ask_choice(question, choices, title=title)
 
-    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None) -> bool:
+    def gui_register_ctx_menu(self, name, action_string, callback_func, category=None, shortcut=None) -> bool:
+        ida_shortcut = _qt_shortcut_to_ida(shortcut) if shortcut else ""
         action = idaapi.action_desc_t(
             name,
             action_string,
             compat.GenericAction(name, callback_func, deci=self),
-            "",
+            ida_shortcut,
             action_string,
             199
         )


### PR DESCRIPTION
Lets plugins specify a Qt-style keyboard shortcut (e.g. "Ctrl+Shift+D") when registering a context menu / plugin action. Each decompiler backend translates the shortcut to its native form:

- IDA: passed as the 4th arg of `idaapi.action_desc_t` ("Ctrl-Shift-D")
- Binja: registered via `UIAction.registerAction` + `UIActionHandler.bindAction`
- Ghidra: `ActionBuilder.keyBinding("ctrl shift D")`
- angr: `QShortcut` on the workspace main window with `ApplicationShortcut` context, kept in `GenericBSAngrManagementPlugin._qshortcuts` to avoid garbage collection