### PR TITLE
Use standard license format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.12",
 ]
-license = {text = "BSD 2 Clause"}
+license = "BSD-2-Clause"
 description = "Your Only Decompiler API Lib - A generic API to script in and out of decompilers"
 urls = {Homepage = "https://github.com/binsync/declib"}
 requires-python = ">= 3.10"


### PR DESCRIPTION
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

<img width="1153" height="40" alt="image" src="https://github.com/user-attachments/assets/5352e7e2-187a-4e94-b111-1d9c0dcc0497" />


I got an error when building d2d for this reason, though i don't get an error when building declib for some reason, but in any case its better to be correct.