### PR TITLE
Expose decompilation line maps in CLI

### DIFF
--- a/.github/workflows/dec-tests.yml
+++ b/.github/workflows/dec-tests.yml
@@ -55,4 +55,8 @@ jobs:
       run: |
         # these two test must be run in separate python environments, due to the way ghidra bridge works
         # you also must run these tests in the exact order shown here
-        TEST_BINARIES_DIR=/tmp/bs-artifacts/binaries pytest tests/test_decompilers.py tests/test_client_server.py -sv
+        TEST_BINARIES_DIR=/tmp/bs-artifacts/binaries pytest \
+          tests/test_decompilers.py \
+          tests/test_client_server.py \
+          tests/test_decompiler_cli.py \
+          -sv

--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -485,6 +485,12 @@ def _known_function_addrs(client) -> set:
 
 
 def cmd_decompile(args) -> int:
+    if args.map_lines and (args.raw or not args.json):
+        raise SystemExit(
+            "decompiler decompile: --map-lines requires --json and cannot "
+            "be combined with --raw"
+        )
+
     with _with_client(args) as client:
         addr = _resolve_function_addr(client, args.target)
         known = _known_function_addrs(client)
@@ -496,7 +502,7 @@ def cmd_decompile(args) -> int:
                 f"Try `decompiler list_functions --filter '{args.target}'` or "
                 "pick a function-start address."
             )
-        dec = client.decompile(addr)
+        dec = client.decompile(addr, map_lines=args.map_lines)
         if dec is None:
             raise SystemExit(
                 f"Decompiler engine returned no result for 0x{addr:x}. "
@@ -514,6 +520,8 @@ def cmd_decompile(args) -> int:
             "decompiler": dec.decompiler if hasattr(dec, "decompiler") else None,
             "text": text,
         }
+        if args.map_lines:
+            out["line_map"] = _format_line_map(getattr(dec, "line_map", None))
         _emit(args, out, text_field="text")
     return 0
 
@@ -1822,6 +1830,27 @@ def _format_addr_hex(value: int) -> str:
     return f"0x{value:x}"
 
 
+def _format_line_map(line_map) -> List[Dict]:
+    """Render a decompilation line map as stable, JSON-friendly records.
+
+    Backend artifacts use ``dict[int, set[int]]`` (with a few backends
+    returning lists). Sets are not JSON serializable and relying on
+    ``default=str`` produces nondeterministic, hard-to-consume output. Keep
+    both integer and hexadecimal address forms, matching the rest of the CLI.
+    """
+    records: List[Dict] = []
+    for line, raw_addrs in sorted((line_map or {}).items(), key=lambda item: int(item[0])):
+        if isinstance(raw_addrs, int):
+            raw_addrs = [raw_addrs]
+        addrs = sorted({int(addr) for addr in raw_addrs})
+        records.append({
+            "line": int(line),
+            "addrs": addrs,
+            "addrs_hex": [_format_addr_hex(addr) for addr in addrs],
+        })
+    return records
+
+
 def _emit(args, payload: Dict, *, text_field: Optional[str] = None) -> None:
     """Emit a response either as JSON or as a human-readable block."""
     if args.json:
@@ -1950,6 +1979,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_dec.add_argument("target", help="Function name or address (hex/decimal).")
     p_dec.add_argument("--raw", action="store_true",
                        help="Print the decompilation text directly (no JSON or header wrapping).")
+    p_dec.add_argument(
+        "--map-lines",
+        action="store_true",
+        help=(
+            "Include backend pseudocode-line to instruction-address mappings "
+            "in JSON output (requires --json)."
+        ),
+    )
     _add_server_filter_args(p_dec)
     _add_output_args(p_dec)
     p_dec.set_defaults(func=cmd_decompile)

--- a/declib/skills/decompiler/SKILL.md
+++ b/declib/skills/decompiler/SKILL.md
@@ -450,6 +450,18 @@ decompiler decompile main --json
 decompiler decompile main --raw
 ```
 
+When statement addresses matter for comments, patches, or control-flow
+reasoning, request the backend's pseudocode line mapping:
+
+```bash
+decompiler decompile main --map-lines --json
+# "line_map": [{"line": 4, "addrs": [1849], "addrs_hex": ["0x739"]}, ...]
+```
+
+Lines can map to multiple instructions, and presentation-only lines may have
+no mapping. `--map-lines` requires `--json` and cannot be combined with
+`--raw`.
+
 ## Gotchas and tips
 
 - **First `load` is slow** (backend analysis pass). Subsequent calls on the

--- a/docs/decompiler_cli.md
+++ b/docs/decompiler_cli.md
@@ -237,7 +237,8 @@ JSON output is a list of `{"addr": int, "size": int, "name": str, "addr_hex": st
 Decompile a function to pseudocode.
 
 ```bash
-decompiler decompile <target> [--raw] [--id ID] [--binary PATH] [--backend BACKEND] [--json]
+decompiler decompile <target> [--raw | --map-lines --json] \
+  [--id ID] [--binary PATH] [--backend BACKEND]
 ```
 
 `<target>` is a function name or address (hex/decimal, lifted or absolute —
@@ -246,9 +247,26 @@ see [Address formats](#address-formats)).
 - **`--raw`** — print the decompilation text directly, skipping all
   wrapping. Useful at a terminal when `--json`'s escaped `\n`s are
   unreadable.
+- **`--map-lines --json`** — ask the backend to map pseudocode lines to the
+  corresponding lifted instruction addresses. The JSON response adds a
+  deterministic `line_map` list. Each record has `line`, sorted integer
+  `addrs`, and matching `addrs_hex` values. A line may map to several
+  instructions, and some pseudocode lines may have no mapping.
 
 Default text output is the decompilation. JSON output includes `addr`,
-`addr_hex`, `decompiler`, and `text`.
+`addr_hex`, `decompiler`, and `text`, plus `line_map` when requested.
+
+```json
+{
+  "addr": 1821,
+  "addr_hex": "0x71d",
+  "decompiler": "ida",
+  "text": "int main(...) { ... }",
+  "line_map": [
+    {"line": 4, "addrs": [1849], "addrs_hex": ["0x739"]}
+  ]
+}
+```
 
 Error messages distinguish three failure modes:
 

--- a/tests/test_decompiler_cli.py
+++ b/tests/test_decompiler_cli.py
@@ -17,7 +17,11 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 from declib.api import server_registry
 from declib.api.decompiler_client import DecompilerClient
@@ -231,6 +235,23 @@ class _CLIBackendTestBase(unittest.TestCase):
         raw = _run_cli("decompile", name, "--raw")
         self.assertNotIn('\\n', raw.stdout)
         self.assertNotIn('{"addr"', raw.stdout)
+
+    def test_decompile_line_map(self):
+        self._load_fauxware()
+        name = self._resolve_main_name()
+        result = _run_cli("decompile", name, "--map-lines", "--json")
+        payload = json.loads(result.stdout)
+
+        self.assertTrue(payload["line_map"], "empty decompilation line map")
+        lines = [entry["line"] for entry in payload["line_map"]]
+        self.assertEqual(lines, sorted(lines))
+        for entry in payload["line_map"]:
+            self.assertIsInstance(entry["line"], int)
+            self.assertEqual(entry["addrs"], sorted(set(entry["addrs"])))
+            self.assertEqual(
+                entry["addrs_hex"],
+                [f"0x{addr:x}" for addr in entry["addrs"]],
+            )
 
     def test_list_strings(self):
         self._load_fauxware()
@@ -1454,6 +1475,59 @@ class TestCLIFormatters(unittest.TestCase):
         annotated = _annotate_addrs(payload)
         self.assertNotIn("-", annotated["addr_hex"])
         self.assertEqual(annotated["target_addr_hex"], "0x1000")
+
+    def test_format_line_map_is_stable_and_json_friendly(self):
+        from declib.cli.decompiler_cli import _format_line_map
+
+        formatted = _format_line_map({4: {0x1020, 0x1010}, 1: [0x1000]})
+        self.assertEqual(
+            formatted,
+            [
+                {"line": 1, "addrs": [0x1000], "addrs_hex": ["0x1000"]},
+                {
+                    "line": 4,
+                    "addrs": [0x1010, 0x1020],
+                    "addrs_hex": ["0x1010", "0x1020"],
+                },
+            ],
+        )
+        json.dumps(formatted)
+
+    def test_map_lines_requires_json(self):
+        result = _run_cli("decompile", "main", "--map-lines", check=False)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--map-lines requires --json", result.stderr)
+
+    def test_decompile_requests_and_emits_line_map(self):
+        from declib.artifacts import Decompilation
+        from declib.cli import decompiler_cli
+
+        client = mock.MagicMock()
+        client.functions = {0x1000: SimpleNamespace(name="main")}
+        client.decompile.return_value = Decompilation(
+            addr=0x1000,
+            text="int main(void) { return 0; }",
+            line_map={2: {0x1010, 0x1008}},
+            decompiler="test",
+        )
+        client_context = mock.MagicMock()
+        client_context.__enter__.return_value = client
+        args = decompiler_cli.build_parser().parse_args(
+            ["decompile", "main", "--map-lines", "--json"]
+        )
+
+        output = StringIO()
+        with mock.patch.object(decompiler_cli, "_with_client", return_value=client_context):
+            with redirect_stdout(output):
+                result = decompiler_cli.cmd_decompile(args)
+
+        self.assertEqual(result, 0)
+        client.decompile.assert_called_once_with(0x1000, map_lines=True)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(
+            payload["line_map"],
+            [{"line": 2, "addrs": [0x1008, 0x1010], "addrs_hex": ["0x1008", "0x1010"]}],
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `decompiler decompile --map-lines --json`
- pass the existing `map_lines=True` request through to the backend
- serialize backend line maps as deterministic records containing a pseudocode line, sorted integer addresses, and matching hex addresses
- reject combinations that would silently discard the mapping (`--raw` or text output)
- document the contract in the CLI guide and bundled agent skill
- run `test_decompiler_cli.py` in the decompiler CI job

## Motivation

DecLib already supports `Decompilation.line_map` across its backends, but the CLI did not expose it. In our ENOWARS 10 agent logs, all 27 IDA decompilation calls requested statement addresses. Agents used those addresses for navigation, comments, and patch analysis, making this one of the most consistently used gaps between the current MCP and DecLib CLI surfaces.

Example output:

```json
"line_map": [
  {"line": 4, "addrs": [1849], "addrs_hex": ["0x739"]}
]
```

A list-of-records contract avoids JSON's string-only object keys and normalizes backend sets/lists into stable, sorted output. It also preserves multiple instruction addresses for one pseudocode line.

## Testing

- `pytest tests/test_decompiler_cli.py::TestCLIFormatters -q` — 5 passed
- `pytest tests/test_artifacts.py tests/test_decompiler_cli.py -q -k 'not test_install_skill_default_falls_back_to_claude'` — 28 passed, 213 skipped, 1 pre-existing environment-sensitive test deselected
- documented core suite (`tests/test_artifacts.py tests/test_cli.py`) — 11 passed
- end-to-end angr smoke test on a temporary arm64 Mach-O: load, `decompile _main --map-lines --json`, and stop all succeeded; output included mapped lines with both single and multiple instruction addresses

The backend-parametrized CLI test will exercise angr, Ghidra, IDA, and Binary Ninja where each dependency/license is available in the existing decompiler CI environment.
