### PR TITLE
Fail fast on decompiler server startup errors

### DIFF
--- a/.github/workflows/dec-tests.yml
+++ b/.github/workflows/dec-tests.yml
@@ -55,4 +55,8 @@ jobs:
       run: |
         # these two test must be run in separate python environments, due to the way ghidra bridge works
         # you also must run these tests in the exact order shown here
-        TEST_BINARIES_DIR=/tmp/bs-artifacts/binaries pytest tests/test_decompilers.py tests/test_client_server.py -sv
+        TEST_BINARIES_DIR=/tmp/bs-artifacts/binaries pytest \
+          tests/test_decompilers.py \
+          tests/test_client_server.py \
+          tests/test_decompiler_cli.py \
+          -sv

--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -64,6 +64,7 @@ _l = logging.getLogger("declib.cli.decompiler")
 
 _SERVER_START_TIMEOUT = 300.0  # seconds; Ghidra initial analysis can be slow
 _SERVER_POLL_INTERVAL = 0.25
+_SERVER_LOG_TAIL_BYTES = 8192
 
 
 def _configure_logging(verbose: bool) -> None:
@@ -206,6 +207,7 @@ def _spawn_server(
     backend: str,
     server_id: str,
     project_dir: Optional[Path] = None,
+    log_path: Optional[Path] = None,
 ) -> subprocess.Popen:
     """Start a detached headless server process for the given binary."""
     cmd = [
@@ -221,10 +223,15 @@ def _spawn_server(
     env = os.environ.copy()
     # Inherit env so things like GHIDRA_INSTALL_DIR flow through.
 
+    if log_path is None:
+        log_path = _server_log_path(server_id)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_stream = log_path.open("wb")
+
     # Fully detach: new session so Ctrl-C in the CLI won't kill the server.
     kwargs = {
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
+        "stdout": log_stream,
+        "stderr": subprocess.STDOUT,
         "stdin": subprocess.DEVNULL,
         "env": env,
         "close_fds": True,
@@ -235,20 +242,70 @@ def _spawn_server(
         kwargs["creationflags"] = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
             subprocess, "CREATE_NEW_PROCESS_GROUP", 0
         )
-    return subprocess.Popen(cmd, **kwargs)
+    try:
+        return subprocess.Popen(cmd, **kwargs)
+    finally:
+        # Popen duplicated the descriptor for the child; the CLI does not need
+        # to keep its copy open while it waits for registration.
+        log_stream.close()
 
 
-def _wait_for_server(server_id: str, timeout: float = _SERVER_START_TIMEOUT) -> Dict:
+def _server_log_path(server_id: str) -> Path:
+    """Keep each detached server's diagnostics beside its Unix socket."""
+    return Path(server_registry.default_socket_path(server_id)).with_name("server.log")
+
+
+def _read_server_log_tail(
+    log_path: Optional[Path],
+    max_bytes: int = _SERVER_LOG_TAIL_BYTES,
+) -> str:
+    if log_path is None:
+        return ""
+    try:
+        with log_path.open("rb") as stream:
+            stream.seek(0, os.SEEK_END)
+            size = stream.tell()
+            stream.seek(max(0, size - max_bytes))
+            return stream.read().decode("utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+
+
+def _server_start_error(message: str, log_path: Optional[Path]) -> SystemExit:
+    lines = [message]
+    if log_path is not None:
+        lines.append(f"Server log: {log_path}")
+        tail = _read_server_log_tail(log_path)
+        if tail:
+            lines.extend(("Server log tail:", tail))
+    return SystemExit("\n".join(lines))
+
+
+def _wait_for_server(
+    server_id: str,
+    process: Optional[subprocess.Popen] = None,
+    log_path: Optional[Path] = None,
+    timeout: float = _SERVER_START_TIMEOUT,
+) -> Dict:
     """Block until a server with `server_id` appears in the registry or timeout."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         record = server_registry.find_server(server_id=server_id)
         if record and record.get("socket_path") and os.path.exists(record["socket_path"]):
             return record
+        if process is not None:
+            exit_status = process.poll()
+            if exit_status is not None:
+                raise _server_start_error(
+                    f"Decompiler server {server_id} exited with status "
+                    f"{exit_status} before registering.",
+                    log_path,
+                )
         time.sleep(_SERVER_POLL_INTERVAL)
-    raise SystemExit(
-        f"Timed out waiting {timeout:.0f}s for server {server_id} to start. "
-        "Check backend dependencies (e.g. GHIDRA_INSTALL_DIR) and retry."
+    raise _server_start_error(
+        f"Timed out waiting {timeout:g}s for server {server_id} to start. "
+        "Check backend dependencies (e.g. GHIDRA_INSTALL_DIR) and retry.",
+        log_path,
     )
 
 
@@ -261,6 +318,11 @@ def cmd_load(args) -> int:
     if backend not in SUPPORTED_DECOMPILERS:
         raise SystemExit(
             f"Unsupported backend {backend!r}; pick one of: {sorted(SUPPORTED_DECOMPILERS)}"
+        )
+    if args.timeout <= 0:
+        raise SystemExit(
+            "decompiler load: --timeout must be greater than zero "
+            f"(got {args.timeout:g})"
         )
 
     # Existing server(s) for this binary+backend.
@@ -293,8 +355,20 @@ def cmd_load(args) -> int:
         project_dir = Path(args.project_dir).expanduser().resolve()
     else:
         project_dir = _default_project_dir(binary_path, backend)
-    _spawn_server(binary_path, backend, server_id, project_dir=project_dir)
-    record = _wait_for_server(server_id)
+    log_path = _server_log_path(server_id)
+    process = _spawn_server(
+        binary_path,
+        backend,
+        server_id,
+        project_dir=project_dir,
+        log_path=log_path,
+    )
+    record = _wait_for_server(
+        server_id,
+        process=process,
+        log_path=log_path,
+        timeout=args.timeout,
+    )
     _emit(args, {
         "status": "started",
         "id": record["id"],
@@ -302,6 +376,7 @@ def cmd_load(args) -> int:
         "backend": record.get("backend"),
         "socket_path": record.get("socket_path"),
         "project_dir": str(project_dir) if project_dir is not None else None,
+        "log_path": str(log_path),
     })
     return 0
 
@@ -1892,6 +1967,15 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Start a new server even if one already exists for this binary.")
     p_load.add_argument("--replace", action="store_true",
                         help="Stop the existing server for this binary+backend (if any) before starting.")
+    p_load.add_argument(
+        "--timeout",
+        type=float,
+        default=_SERVER_START_TIMEOUT,
+        help=(
+            "Seconds to wait for backend startup (default: "
+            f"{_SERVER_START_TIMEOUT:g})."
+        ),
+    )
     p_load.add_argument(
         "--project-dir",
         dest="project_dir",

--- a/declib/skills/decompiler/SKILL.md
+++ b/declib/skills/decompiler/SKILL.md
@@ -49,6 +49,11 @@ decompiler list_functions --filter 'main|auth' # or narrow by regex
 decompiler list_strings --filter 'flag|pass'   # find interesting string constants
 ```
 
+If `load` fails, read the reported server-log tail before trying another
+backend; startup child failures are surfaced immediately. Use
+`--timeout SECONDS` to fit a strict task budget or allow an unusually slow
+initial analysis. Successful JSON output includes the persistent `log_path`.
+
 Typical first-hour workflow on a stripped binary:
 
 1. `decompiler load ./bin --backend ida` (fall back to `--backend ghidra`,

--- a/docs/decompiler_cli.md
+++ b/docs/decompiler_cli.md
@@ -131,6 +131,7 @@ it.
 decompiler load <binary> [--backend {angr,ghidra,binja,ida}]
                          [--id SERVER_ID]
                          [--force | --replace]
+                         [--timeout SECONDS]
                          [--project-dir PATH]
                          [--json]
 ```
@@ -142,6 +143,9 @@ decompiler load <binary> [--backend {angr,ghidra,binja,ida}]
 - **`--replace`** — stop any existing server for this `(binary, backend)`
   first, then start a fresh one. Use this when you want to re-analyze from
   scratch.
+- **`--timeout SECONDS`** (default: 300) — maximum time to wait for the
+  backend to register. Slow Ghidra or IDA analyses may need a larger value;
+  use a smaller value in automation when a strict task timebox matters.
 - **`--project-dir PATH`** — where to keep the backend's
   project/database files (Ghidra project, IDA `.id*`/`.til`, etc.).
   Default: a per-binary directory under the user cache
@@ -150,8 +154,16 @@ decompiler load <binary> [--backend {angr,ghidra,binja,ida}]
   to disable the cache dir and let the backend drop files alongside the
   binary (legacy behavior).
 
-Outputs `id`, `socket_path`, `binary_path`, `backend`, `project_dir`, and
-`status` (either `started` or `already_loaded`).
+For a newly started server, output includes `id`, `socket_path`, `binary_path`,
+`backend`, `project_dir`, `log_path`, and `status`. `status` is either
+`started` or `already_loaded` (the latter describes an existing server and
+does not add a new `log_path`).
+
+Detached server stdout and stderr are written to `log_path`. If the child
+exits before registering, `load` fails immediately instead of waiting for the
+full timeout and prints the final 8 KiB of that log. A timeout reports the same
+path and bounded tail, which usually reveals a missing dependency, license
+failure, backend exception, or stale project problem.
 
 ### `list`
 

--- a/tests/test_decompiler_cli.py
+++ b/tests/test_decompiler_cli.py
@@ -18,6 +18,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from declib.api import server_registry
 from declib.api.decompiler_client import DecompilerClient
@@ -156,6 +157,9 @@ class _CLIBackendTestBase(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertIn(payload["status"], ("started", "already_loaded"))
         self.assertEqual(payload["backend"], self.backend)
+        if payload["status"] == "started":
+            self.assertIn("log_path", payload)
+            self.assertTrue(Path(payload["log_path"]).is_file())
         return payload
 
     def _resolve_main_name(self):
@@ -1454,6 +1458,58 @@ class TestCLIFormatters(unittest.TestCase):
         annotated = _annotate_addrs(payload)
         self.assertNotIn("-", annotated["addr_hex"])
         self.assertEqual(annotated["target_addr_hex"], "0x1000")
+
+    def test_wait_for_server_reports_early_child_exit_and_log(self):
+        from declib.cli import decompiler_cli
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "server.log"
+            log_path.write_text("backend import failed\ntraceback details\n")
+            process = mock.Mock()
+            process.poll.return_value = 17
+
+            with mock.patch.object(
+                decompiler_cli.server_registry, "find_server", return_value=None
+            ):
+                with self.assertRaises(SystemExit) as raised:
+                    decompiler_cli._wait_for_server(
+                        "deadbeef",
+                        process=process,
+                        log_path=log_path,
+                        timeout=300,
+                    )
+
+        message = str(raised.exception)
+        self.assertIn("exited with status 17", message)
+        self.assertIn(str(log_path), message)
+        self.assertIn("backend import failed", message)
+
+    def test_wait_for_server_timeout_includes_bounded_log_tail(self):
+        from declib.cli import decompiler_cli
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = Path(tmpdir) / "server.log"
+            log_path.write_text("discard-me\n" + "x" * 32 + "useful tail\n")
+            tail = decompiler_cli._read_server_log_tail(log_path, max_bytes=16)
+            self.assertNotIn("discard-me", tail)
+            self.assertTrue(tail.endswith("useful tail"))
+
+            with self.assertRaises(SystemExit) as raised:
+                decompiler_cli._wait_for_server(
+                    "slowserver",
+                    log_path=log_path,
+                    timeout=0,
+                )
+
+        message = str(raised.exception)
+        self.assertIn("Timed out waiting 0s", message)
+        self.assertIn("Server log tail", message)
+
+    def test_load_timeout_argument(self):
+        from declib.cli.decompiler_cli import build_parser
+
+        args = build_parser().parse_args(["load", "/tmp/example", "--timeout", "12.5"])
+        self.assertEqual(args.timeout, 12.5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- capture detached decompiler-server stdout/stderr in a per-server log beside its socket
- monitor the spawned child while waiting for registry registration
- fail immediately when the child exits, including its status, log path, and final 8 KiB of output
- include the same bounded diagnostic tail on startup timeout
- add `decompiler load --timeout SECONDS` (default remains 300 seconds)
- return `log_path` when a new server starts successfully
- document the behavior in the CLI guide and bundled agent skill

## Motivation

`decompiler load` previously sent detached child output to `/dev/null` and only watched the registry. A missing dependency, license problem, socket failure, or backend crash therefore looked identical to slow analysis and consumed the full five-minute timeout.

We reproduced this both during an ENOWARS workload replay and locally. In the local regression case, angr initialized but the server could not bind its socket. Before this change, `load` waited 300 seconds and reported only a generic timeout. With this change, it failed in 2.9 seconds and surfaced the exact child error:

```text
Decompiler server ... exited with status 1 before registering.
Server log: .../declib_server_.../server.log
Server log tail:
...
Failed to start server: [Errno 1] Operation not permitted
```

The configurable timeout also lets automation choose between a strict task budget and unusually slow initial Ghidra/IDA analysis.

## Testing

- lifecycle helper tests: early child exit, bounded log tail, timeout reporting, and parser contract — 5 passed
- `tests/test_artifacts.py` plus backend-independent `test_decompiler_cli.py` cases — 28 passed, 209 skipped, 1 pre-existing environment-sensitive test deselected
- documented core suite (`tests/test_artifacts.py tests/test_cli.py`) — 11 passed
- end-to-end failure regression — returned the child error and log in 2.9 seconds instead of 300 seconds
- end-to-end success regression — temporary angr server started in 2.2 seconds, JSON included an existing `log_path`, and the server stopped cleanly

The decompiler CI job now includes `test_decompiler_cli.py`, so the existing backend matrix also verifies that newly started IDA, Ghidra, Binary Ninja, and angr servers return a real log path where available.
