### PR TITLE
Add agent-safe decompilation output shaping

### DIFF
--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -36,6 +36,7 @@ Subcommands implemented:
 - install-skill   install the bundled Agent Skill so LLMs learn the CLI
 """
 import argparse
+import hashlib
 import json
 import logging
 import os
@@ -559,12 +560,159 @@ def _known_function_addrs(client) -> set:
         return set()
 
 
+def _parse_line_range_specs(specs: Optional[List[str]]) -> List[Tuple[Optional[int], Optional[int]]]:
+    """Parse 1-based inclusive ``START:END`` ranges, allowing either side open."""
+    ranges = []
+    for spec in specs or []:
+        match = re.fullmatch(r"(\d*):(\d*)", spec)
+        if match is None or not any(match.groups()):
+            raise SystemExit(
+                f"Invalid --lines range {spec!r}; use START:END, START:, or :END."
+            )
+        start = int(match.group(1)) if match.group(1) else None
+        end = int(match.group(2)) if match.group(2) else None
+        if start is not None and start < 1:
+            raise SystemExit(f"Invalid --lines range {spec!r}; START must be at least 1.")
+        if end is not None and end < 1:
+            raise SystemExit(f"Invalid --lines range {spec!r}; END must be at least 1.")
+        if start is not None and end is not None and end < start:
+            raise SystemExit(f"Invalid --lines range {spec!r}; END precedes START.")
+        ranges.append((start, end))
+    return ranges
+
+
+def _compile_grep_patterns(patterns: Optional[List[str]], ignore_case: bool) -> List[re.Pattern]:
+    flags = re.IGNORECASE if ignore_case else 0
+    try:
+        return [re.compile(pattern, flags) for pattern in patterns or []]
+    except re.error as exc:
+        raise SystemExit(f"Invalid --grep regular expression: {exc}") from exc
+
+
+def _coalesce_line_numbers(line_numbers) -> List[Dict[str, int]]:
+    """Turn 1-based line numbers into compact inclusive source ranges."""
+    ordered = sorted(set(line_numbers))
+    if not ordered:
+        return []
+    ranges = []
+    start = previous = ordered[0]
+    for line in ordered[1:]:
+        if line == previous + 1:
+            previous = line
+            continue
+        ranges.append({"start": start, "end": previous})
+        start = previous = line
+    ranges.append({"start": start, "end": previous})
+    return ranges
+
+
+def _shape_decompilation_text(
+    text: str,
+    *,
+    line_ranges: Optional[List[Tuple[Optional[int], Optional[int]]]] = None,
+    grep_patterns: Optional[List[re.Pattern]] = None,
+    context: int = 0,
+    max_chars: Optional[int] = None,
+) -> Dict:
+    """Select and bound pseudocode while retaining original source line numbers."""
+    lines = text.splitlines(keepends=True)
+    total_lines = len(lines)
+    selected = set(range(1, total_lines + 1))
+    matched_lines: List[int] = []
+
+    if line_ranges:
+        selected = set()
+        for requested_start, requested_end in line_ranges:
+            start = requested_start or 1
+            end = requested_end or total_lines
+            selected.update(range(start, min(end, total_lines) + 1))
+    elif grep_patterns:
+        selected = set()
+        for line_number, line in enumerate(lines, start=1):
+            if any(pattern.search(line) for pattern in grep_patterns):
+                matched_lines.append(line_number)
+                first = max(1, line_number - context)
+                last = min(total_lines, line_number + context)
+                selected.update(range(first, last + 1))
+
+    chunks = [(line_number, lines[line_number - 1]) for line_number in sorted(selected)]
+    selected_chars = sum(len(chunk) for _, chunk in chunks)
+    used_lines = []
+    output_chunks = []
+    remaining = max_chars
+    for line_number, chunk in chunks:
+        if remaining is not None and remaining <= 0:
+            break
+        if remaining is not None and len(chunk) > remaining:
+            output_chunks.append(chunk[:remaining])
+            used_lines.append(line_number)
+            remaining = 0
+            break
+        output_chunks.append(chunk)
+        used_lines.append(line_number)
+        if remaining is not None:
+            remaining -= len(chunk)
+
+    output_text = "".join(output_chunks)
+    return {
+        "text": output_text,
+        "total_chars": len(text),
+        "total_lines": total_lines,
+        "selected_chars": selected_chars,
+        "output_chars": len(output_text),
+        "output_lines": len(output_text.splitlines()),
+        "source_ranges": _coalesce_line_numbers(used_lines),
+        "matched_lines": matched_lines,
+        "truncated": len(output_text) < selected_chars,
+        "bounded": bool(line_ranges or grep_patterns or max_chars is not None),
+        "selected_source_lines": set(used_lines),
+    }
+
+
+def _prepare_decompilation_output(path_value: str, force: bool) -> Path:
+    path = Path(path_value).expanduser().resolve()
+    if path.exists() and not force:
+        raise SystemExit(f"Output path already exists: {path}. Pass --force-output to overwrite it.")
+    return path
+
+
+def _write_decompilation_output(path: Path, text: str) -> Dict:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = text.encode("utf-8")
+    path.write_bytes(encoded)
+    return {
+        "path": str(path),
+        "bytes": len(encoded),
+        "sha256": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
 def cmd_decompile(args) -> int:
     if args.map_lines and (args.raw or not args.json):
         raise SystemExit(
             "decompiler decompile: --map-lines requires --json and cannot "
             "be combined with --raw"
         )
+    if args.output and args.raw:
+        raise SystemExit("decompiler decompile: --output cannot be combined with --raw")
+    if args.force_output and not args.output:
+        raise SystemExit("decompiler decompile: --force-output requires --output")
+    if args.context < 0:
+        raise SystemExit("decompiler decompile: --context must be zero or greater")
+    if args.context and not args.grep:
+        raise SystemExit("decompiler decompile: --context requires --grep")
+    if args.ignore_case and not args.grep:
+        raise SystemExit("decompiler decompile: --ignore-case requires --grep")
+    if args.max_chars is not None and args.max_chars < 1:
+        raise SystemExit("decompiler decompile: --max-chars must be at least 1")
+
+    line_ranges = _parse_line_range_specs(args.lines)
+    grep_patterns = _compile_grep_patterns(args.grep, args.ignore_case)
+    output_path = (
+        _prepare_decompilation_output(args.output, args.force_output)
+        if args.output
+        else None
+    )
 
     with _with_client(args) as client:
         addr = _resolve_function_addr(client, args.target)
@@ -586,17 +734,46 @@ def cmd_decompile(args) -> int:
                 "function (unreachable code, ARM/x86 mode mismatch, etc.)."
             )
         text = dec.text if hasattr(dec, "text") else str(dec)
+        shaped = _shape_decompilation_text(
+            text,
+            line_ranges=line_ranges,
+            grep_patterns=grep_patterns,
+            context=args.context,
+            max_chars=args.max_chars,
+        )
+        output_text = shaped.pop("text")
+        selected_source_lines = shaped.pop("selected_source_lines")
+        output = None
+        if output_path is not None:
+            output = _write_decompilation_output(output_path, output_text)
         if getattr(args, "raw", False):
             # --raw: dump just the text body to stdout, regardless of --json.
-            print(text)
+            print(output_text, end="" if output_text.endswith("\n") else "\n")
             return 0
         out = {
             "addr": addr,
             "decompiler": dec.decompiler if hasattr(dec, "decompiler") else None,
-            "text": text,
         }
+        shaping_requested = bool(
+            args.lines or args.grep or args.max_chars is not None or args.output
+        )
+        if output is None:
+            out["text"] = output_text
+        else:
+            out["output"] = output
+        if shaping_requested:
+            out.update(shaped)
         if args.map_lines:
-            out["line_map"] = _format_line_map(getattr(dec, "line_map", None))
+            out["line_map"] = _format_line_map(
+                getattr(dec, "line_map", None),
+                selected_lines=selected_source_lines if shaping_requested else None,
+            )
+        if output is not None and not args.json:
+            print(
+                f"Wrote {output['bytes']} bytes to {output['path']} "
+                f"(sha256 {output['sha256']})"
+            )
+            return 0
         _emit(args, out, text_field="text")
     return 0
 
@@ -1905,7 +2082,7 @@ def _format_addr_hex(value: int) -> str:
     return f"0x{value:x}"
 
 
-def _format_line_map(line_map) -> List[Dict]:
+def _format_line_map(line_map, selected_lines=None) -> List[Dict]:
     """Render a decompilation line map as stable, JSON-friendly records.
 
     Backend artifacts use ``dict[int, set[int]]`` (with a few backends
@@ -1915,6 +2092,8 @@ def _format_line_map(line_map) -> List[Dict]:
     """
     records: List[Dict] = []
     for line, raw_addrs in sorted((line_map or {}).items(), key=lambda item: int(item[0])):
+        if selected_lines is not None and int(line) not in selected_lines:
+            continue
         if isinstance(raw_addrs, int):
             raw_addrs = [raw_addrs]
         addrs = sorted({int(addr) for addr in raw_addrs})
@@ -2070,6 +2249,48 @@ def build_parser() -> argparse.ArgumentParser:
             "Include backend pseudocode-line to instruction-address mappings "
             "in JSON output (requires --json)."
         ),
+    )
+    selection = p_dec.add_mutually_exclusive_group()
+    selection.add_argument(
+        "--lines",
+        action="append",
+        metavar="START:END",
+        help=(
+            "Return 1-based inclusive pseudocode line ranges. Repeat for "
+            "multiple ranges; START or END may be omitted."
+        ),
+    )
+    selection.add_argument(
+        "--grep",
+        action="append",
+        metavar="REGEX",
+        help="Return lines matching a regex. Repeat to match any regex.",
+    )
+    p_dec.add_argument(
+        "--context",
+        type=int,
+        default=0,
+        help="Include N surrounding lines for each --grep match (default: 0).",
+    )
+    p_dec.add_argument(
+        "--ignore-case",
+        action="store_true",
+        help="Match --grep patterns case-insensitively.",
+    )
+    p_dec.add_argument(
+        "--max-chars",
+        type=int,
+        help="Limit shaped pseudocode to at most N characters.",
+    )
+    p_dec.add_argument(
+        "--output",
+        metavar="PATH",
+        help="Write shaped pseudocode to PATH and return only file metadata.",
+    )
+    p_dec.add_argument(
+        "--force-output",
+        action="store_true",
+        help="Allow --output to overwrite an existing file.",
     )
     _add_server_filter_args(p_dec)
     _add_output_args(p_dec)

--- a/declib/skills/decompiler/SKILL.md
+++ b/declib/skills/decompiler/SKILL.md
@@ -137,7 +137,7 @@ same binary.
 | `stop` | Shut down one or all servers. `--save` flushes analysis to disk first; `--discard` drops unsaved edits. | `--id`, `--binary`, `--all`, `--save`, `--discard`, `--json` |
 | `save` | Persist backend analysis to disk so renames/types/comments survive a reload. | `--path`, `--id`, `--binary`, `--backend`, `--json` |
 | `list_functions` | Enumerate every function (ADDR, SIZE, NAME). | `--filter REGEX`, `--json` |
-| `decompile <target>` | Pseudocode for a function (name or address). | `--raw`, `--id`, `--binary`, `--backend`, `--json` |
+| `decompile <target>` | Pseudocode for a function (name or address). | `--raw`, `--map-lines`, `--lines`, `--grep`, `--context`, `--max-chars`, `--output`, `--json` |
 | `disassemble <target>` | Assembly for a function. | `--raw`, same |
 | `xref_to <target>` | Every reference (code + data) to the target. | `--decompile`, same |
 | `xref_from <target>` | Functions that `target` calls. | same |
@@ -466,6 +466,26 @@ decompiler decompile main --map-lines --json
 Lines can map to multiple instructions, and presentation-only lines may have
 no mapping. `--map-lines` requires `--json` and cannot be combined with
 `--raw`.
+
+Never send a giant function to model context repeatedly. Shape one
+decompilation at the CLI:
+
+```bash
+# Inspect one or several 1-based inclusive source ranges.
+decompiler decompile processClientInput --lines 1450:1700 --json
+
+# Search pseudocode and include nearby control flow.
+decompiler decompile processClientInput \
+  --grep 'firmware|readlog' --context 8 --ignore-case --json
+
+# Save the complete result once; the response contains path/hash/size, not text.
+decompiler decompile processClientInput --output /tmp/processClientInput.c --json
+```
+
+Shaped JSON reports original and output sizes, source ranges, match lines, and
+whether `--max-chars` truncated the result. Repeat `--lines` or `--grep` in one
+request instead of decompiling the same function again. Existing output files
+require `--force-output` before they are overwritten.
 
 ## Gotchas and tips
 

--- a/docs/decompiler_cli.md
+++ b/docs/decompiler_cli.md
@@ -250,6 +250,8 @@ Decompile a function to pseudocode.
 
 ```bash
 decompiler decompile <target> [--raw | --map-lines --json] \
+  [--lines START:END ... | --grep REGEX ... [--context N] [--ignore-case]] \
+  [--max-chars N] [--output PATH [--force-output]] \
   [--id ID] [--binary PATH] [--backend BACKEND]
 ```
 
@@ -264,9 +266,26 @@ see [Address formats](#address-formats)).
   deterministic `line_map` list. Each record has `line`, sorted integer
   `addrs`, and matching `addrs_hex` values. A line may map to several
   instructions, and some pseudocode lines may have no mapping.
+- **`--lines START:END`** — return only a 1-based inclusive pseudocode line
+  range. Repeat it for multiple ranges; `START:` and `:END` are accepted.
+- **`--grep REGEX`** — return lines matching a regular expression. Repeat it
+  to match any expression. `--context N` adds surrounding lines and
+  `--ignore-case` changes all patterns to case-insensitive matching.
+  `--grep` and `--lines` are mutually exclusive.
+- **`--max-chars N`** — cap the selected pseudocode at exactly `N`
+  characters. Metadata reports whether truncation occurred.
+- **`--output PATH`** — write the selected pseudocode to a UTF-8 file and
+  return only its absolute path, byte count, and SHA-256 digest instead of
+  sending the body to stdout. Existing files are protected unless
+  `--force-output` is supplied.
 
 Default text output is the decompilation. JSON output includes `addr`,
 `addr_hex`, `decompiler`, and `text`, plus `line_map` when requested.
+When any shaping option is used, JSON also includes `total_chars`,
+`total_lines`, `selected_chars`, `output_chars`, `output_lines`,
+`source_ranges`, `matched_lines`, `truncated`, and `bounded`. Line mappings
+are restricted to selected source lines. `--output` replaces `text` with an
+`output` metadata object, keeping large pseudocode out of agent context.
 
 ```json
 {
@@ -278,6 +297,20 @@ Default text output is the decompilation. JSON output includes `addr`,
     {"line": 4, "addrs": [1849], "addrs_hex": ["0x739"]}
   ]
 }
+```
+
+Examples for a very large function:
+
+```bash
+# Inspect a known source region without returning the other 10,000 lines.
+decompiler decompile processClientInput --lines 1450:1700 --json
+
+# Find two concepts and include eight lines of context around every match.
+decompiler decompile processClientInput \
+  --grep 'firmware|readlog' --context 8 --ignore-case --json
+
+# Materialize once for later local rg/sed work; stdout contains metadata only.
+decompiler decompile processClientInput --output /tmp/processClientInput.c --json
 ```
 
 Error messages distinguish three failure modes:

--- a/tests/test_decompiler_cli.py
+++ b/tests/test_decompiler_cli.py
@@ -239,6 +239,17 @@ class _CLIBackendTestBase(unittest.TestCase):
         self.assertNotIn('\\n', raw.stdout)
         self.assertNotIn('{"addr"', raw.stdout)
 
+    def test_decompile_line_range(self):
+        self._load_fauxware()
+        name = self._resolve_main_name()
+        result = _run_cli("decompile", name, "--lines", "1:2", "--json")
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["bounded"])
+        self.assertFalse(payload["truncated"])
+        self.assertLessEqual(payload["output_lines"], 2)
+        self.assertEqual(payload["source_ranges"], [{"start": 1, "end": 2}])
+        self.assertLessEqual(payload["output_chars"], payload["total_chars"])
+
     def test_decompile_line_map(self):
         self._load_fauxware()
         name = self._resolve_main_name()
@@ -1531,6 +1542,125 @@ class TestCLIFormatters(unittest.TestCase):
             payload["line_map"],
             [{"line": 2, "addrs": [0x1008, 0x1010], "addrs_hex": ["0x1008", "0x1010"]}],
         )
+
+    def test_parse_and_shape_line_ranges(self):
+        from declib.cli.decompiler_cli import (
+            _parse_line_range_specs,
+            _shape_decompilation_text,
+        )
+
+        ranges = _parse_line_range_specs(["2:3", "5:"])
+        shaped = _shape_decompilation_text(
+            "one\ntwo\nthree\nfour\nfive\n",
+            line_ranges=ranges,
+        )
+        self.assertEqual(shaped["text"], "two\nthree\nfive\n")
+        self.assertEqual(
+            shaped["source_ranges"],
+            [{"start": 2, "end": 3}, {"start": 5, "end": 5}],
+        )
+        self.assertEqual(shaped["total_lines"], 5)
+        self.assertTrue(shaped["bounded"])
+        self.assertFalse(shaped["truncated"])
+
+    def test_shape_grep_context_and_character_limit(self):
+        from declib.cli.decompiler_cli import (
+            _compile_grep_patterns,
+            _shape_decompilation_text,
+        )
+
+        patterns = _compile_grep_patterns(["firmware", "ADMIN"], ignore_case=True)
+        shaped = _shape_decompilation_text(
+            "zero\none\nfirmware check\nthree\nadmin path\nfive\n",
+            grep_patterns=patterns,
+            context=1,
+            max_chars=24,
+        )
+        self.assertEqual(shaped["matched_lines"], [3, 5])
+        self.assertEqual(shaped["source_ranges"], [{"start": 2, "end": 4}])
+        self.assertEqual(shaped["text"], "one\nfirmware check\nthree")
+        self.assertTrue(shaped["truncated"])
+        self.assertEqual(shaped["output_chars"], 24)
+
+    def test_invalid_line_ranges_fail_before_decompilation(self):
+        from declib.cli.decompiler_cli import _parse_line_range_specs
+
+        for spec in ("", ":", "0:4", "5:2", "abc"):
+            with self.subTest(spec=spec):
+                with self.assertRaises(SystemExit):
+                    _parse_line_range_specs([spec])
+
+    def test_decompile_output_file_omits_text_and_decompiles_once(self):
+        from declib.artifacts import Decompilation
+        from declib.cli import decompiler_cli
+
+        client = mock.MagicMock()
+        client.functions = {0x1000: SimpleNamespace(name="main")}
+        client.decompile.return_value = Decompilation(
+            addr=0x1000,
+            text="int main(void) {\n  return 0;\n}\n",
+            decompiler="test",
+        )
+        client_context = mock.MagicMock()
+        client_context.__enter__.return_value = client
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "main.c"
+            args = decompiler_cli.build_parser().parse_args(
+                [
+                    "decompile",
+                    "main",
+                    "--grep",
+                    "return",
+                    "--context",
+                    "1",
+                    "--output",
+                    str(output_path),
+                    "--json",
+                ]
+            )
+            stdout = StringIO()
+            with mock.patch.object(
+                decompiler_cli, "_with_client", return_value=client_context
+            ):
+                with redirect_stdout(stdout):
+                    result = decompiler_cli.cmd_decompile(args)
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(output_path.read_text(), "int main(void) {\n  return 0;\n}\n")
+
+        self.assertEqual(result, 0)
+        client.decompile.assert_called_once_with(0x1000, map_lines=False)
+        self.assertNotIn("text", payload)
+        self.assertEqual(payload["output"]["path"], str(output_path.resolve()))
+        self.assertEqual(payload["output"]["bytes"], 31)
+        self.assertEqual(payload["matched_lines"], [2])
+
+    def test_format_line_map_can_filter_selected_source_lines(self):
+        from declib.cli.decompiler_cli import _format_line_map
+
+        formatted = _format_line_map(
+            {1: {0x1000}, 2: {0x1010}, 3: {0x1020}},
+            selected_lines={2, 3},
+        )
+        self.assertEqual([entry["line"] for entry in formatted], [2, 3])
+
+    def test_existing_output_fails_before_connecting_to_backend(self):
+        from declib.cli import decompiler_cli
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "existing.c"
+            output_path.write_text("keep me")
+            args = decompiler_cli.build_parser().parse_args(
+                ["decompile", "main", "--output", str(output_path), "--json"]
+            )
+            with mock.patch.object(decompiler_cli, "_with_client") as connect:
+                with self.assertRaises(SystemExit):
+                    decompiler_cli.cmd_decompile(args)
+
+            connect.assert_not_called()
+            self.assertEqual(output_path.read_text(), "keep me")
+
     def test_wait_for_server_reports_early_child_exit_and_log(self):
         from declib.cli import decompiler_cli
 


### PR DESCRIPTION
## Summary

- add repeatable `decompiler decompile --lines START:END` ranges
- add repeatable `--grep REGEX`, `--context N`, and `--ignore-case`
- add exact `--max-chars N` truncation
- add `--output PATH` with path/byte-count/SHA-256 metadata and overwrite protection
- report original, selected, and returned sizes; source ranges; regex match lines; and truncation/bounded status
- restrict `--map-lines` results to the selected source lines
- preserve the existing unshaped CLI output contract
- document agent-safe large-function workflows in the CLI guide and bundled skill

## Motivation

In our ENOWARS 10 agent logs, one C++ function produced roughly 100 KB of pseudocode. The ordinary MCP response truncated it, so the agent made 12 backend-Python calls to export the full function, grep it, and return line slices. It also tried ordinary decompilation four times.

This change makes that workflow first-class while performing only one backend decompilation per CLI invocation:

```bash
decompiler decompile processClientInput --lines 1450:1700 --json
decompiler decompile processClientInput \
  --grep 'firmware|readlog' --context 8 --ignore-case --json
decompiler decompile processClientInput \
  --output /tmp/processClientInput.c --json
```

`--output` deliberately omits the pseudocode body from stdout, allowing an agent to materialize it once and use local `rg`/`sed` without putting the whole function in model context. Existing files require `--force-output`, and that conflict is detected before connecting to the backend.

## Output contract

Shaped JSON adds:

- `total_chars` / `total_lines`
- `selected_chars`
- `output_chars` / `output_lines`
- `source_ranges` (1-based, inclusive)
- `matched_lines`
- `truncated` and `bounded`

When `--output` is used, `text` is replaced by:

```json
{"output": {"path": "/tmp/function.c", "bytes": 100918, "sha256": "..."}}
```

## Testing

- formatter/contract tests: 14 passed plus 5 range-validation subtests
- documented core suite: 11 passed
- broader backend-independent CLI suite: 32 passed, 217 backend/dependency skips, one pre-existing environment-sensitive test deselected
- compile and whitespace checks passed
- live angr smoke test on an arm64 Mach-O verified:
  - two disjoint line ranges
  - multi-pattern grep with context, case folding, and filtered line maps
  - exact 80-character truncation
  - file output with a matching 419-byte size and SHA-256
  - clean server shutdown

The backend-parametrized test also exercises a shaped line range on every available decompiler in CI.
