### PR TITLE
Add persistent CLI batch operations

### DIFF
--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -9,6 +9,7 @@ via the shared server registry (see declib.api.server_registry).
 Subcommands implemented:
 - load            start a server on a binary
 - list            list running servers
+- batch           execute JSONL CLI operations through one client connection
 - stop            stop one or all servers (with --save/--discard)
 - save            persist backend analysis to disk (durable artifacts)
 - list_functions  list functions in the binary, optionally filtered by regex
@@ -36,7 +37,10 @@ Subcommands implemented:
 - install-skill   install the bundled Agent Skill so LLMs learn the CLI
 """
 import argparse
+from contextlib import redirect_stderr, redirect_stdout
+from contextvars import ContextVar
 import hashlib
+from io import StringIO
 import json
 import logging
 import os
@@ -66,6 +70,15 @@ _l = logging.getLogger("declib.cli.decompiler")
 _SERVER_START_TIMEOUT = 300.0  # seconds; Ghidra initial analysis can be slow
 _SERVER_POLL_INTERVAL = 0.25
 _SERVER_LOG_TAIL_BYTES = 8192
+_BATCH_CLIENT = ContextVar("declib_batch_client", default=None)
+_BATCH_DISALLOWED_COMMANDS = {
+    "batch",
+    "install-skill",
+    "list",
+    "load",
+    "stop",
+    "sync",
+}
 
 
 def _configure_logging(verbose: bool) -> None:
@@ -189,8 +202,24 @@ def _connect_client(record: Dict):
     return DecompilerClient(socket_path=record["socket_path"])
 
 
+class _BorrowedClient:
+    """Context manager that lends a batch's client without closing it."""
+
+    def __init__(self, client):
+        self.client = client
+
+    def __enter__(self):
+        return self.client
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
 def _with_client(args):
     """Resolve & connect to the selected server, returning the client."""
+    batch_client = _BATCH_CLIENT.get()
+    if batch_client is not None:
+        return _BorrowedClient(batch_client)
     record = _select_server(
         server_id=getattr(args, "id", None),
         binary_path=getattr(args, "binary", None),
@@ -547,6 +576,192 @@ def cmd_save(args) -> int:
             )
         _emit(args, {"saved": ok, "path": args.path})
         return EXIT_OK if ok else EXIT_USER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# batch
+# ---------------------------------------------------------------------------
+
+def _read_batch_operations(args) -> List[Dict]:
+    if args.file:
+        try:
+            lines = Path(args.file).expanduser().read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            raise SystemExit(f"Could not read batch file {args.file!r}: {exc}") from exc
+    else:
+        lines = sys.stdin.read().splitlines()
+
+    operations = []
+    seen_ids = set()
+    for line_number, line in enumerate(lines, start=1):
+        if not line.strip():
+            continue
+        default_id = f"line-{line_number}"
+        try:
+            value = json.loads(line)
+        except json.JSONDecodeError as exc:
+            operations.append({
+                "id": default_id,
+                "_input_error": f"Invalid JSON on line {line_number}: {exc.msg}",
+            })
+            continue
+        if not isinstance(value, dict):
+            operations.append({
+                "id": default_id,
+                "_input_error": f"Batch line {line_number} must be a JSON object.",
+            })
+            continue
+
+        operation_id = value.get("id", default_id)
+        if not isinstance(operation_id, (str, int)):
+            operation_id = default_id
+            value["_input_error"] = f"Batch line {line_number} id must be a string or integer."
+        if operation_id in seen_ids:
+            value["_input_error"] = f"Duplicate batch operation id: {operation_id!r}."
+        seen_ids.add(operation_id)
+        value["id"] = operation_id
+        argv = value.get("argv")
+        if "_input_error" not in value and (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(item, str) for item in argv)
+        ):
+            value["_input_error"] = (
+                f"Batch line {line_number} needs a non-empty string array in 'argv'."
+            )
+        operations.append(value)
+    return operations
+
+
+def _batch_result(operation: Dict, *, exit_code: int, **fields) -> Dict:
+    result = {
+        "id": operation.get("id"),
+        "ok": exit_code == EXIT_OK,
+        "exit_code": exit_code,
+    }
+    argv = operation.get("argv")
+    if isinstance(argv, list) and argv:
+        result["command"] = argv[0]
+    result.update(fields)
+    return result
+
+
+def _batch_option_present(argv: List[str], option: str) -> bool:
+    return any(token == option or token.startswith(f"{option}=") for token in argv)
+
+
+def _execute_batch_operation(operation: Dict, batch_args) -> Dict:
+    started = time.perf_counter()
+    if operation.get("_input_error"):
+        return _batch_result(
+            operation,
+            exit_code=EXIT_USER_ERROR,
+            error=operation["_input_error"],
+            duration_ms=0,
+        )
+
+    argv = list(operation["argv"])
+    command = argv[0]
+    if command in _BATCH_DISALLOWED_COMMANDS:
+        return _batch_result(
+            operation,
+            exit_code=EXIT_USER_ERROR,
+            error=f"Command {command!r} is not allowed inside a batch.",
+            duration_ms=0,
+        )
+    for option in ("--id", "--binary", "--backend"):
+        if _batch_option_present(argv, option):
+            return _batch_result(
+                operation,
+                exit_code=EXIT_USER_ERROR,
+                error=f"Batch operations inherit the batch target; remove {option}.",
+                duration_ms=0,
+            )
+    for option in ("--raw", "--help", "-h"):
+        if _batch_option_present(argv, option):
+            return _batch_result(
+                operation,
+                exit_code=EXIT_USER_ERROR,
+                error=f"{option} is not allowed inside a structured batch.",
+                duration_ms=0,
+            )
+
+    if not _batch_option_present(argv, "--json"):
+        argv.append("--json")
+    stdout = StringIO()
+    stderr = StringIO()
+    exit_code = EXIT_OK
+    error = None
+    result_payload = None
+    try:
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            operation_args = build_parser().parse_args(argv)
+            if operation_args.cmd in _BATCH_DISALLOWED_COMMANDS:
+                raise SystemExit(
+                    f"Command {operation_args.cmd!r} is not allowed inside a batch."
+                )
+            for attr in ("id", "binary", "backend"):
+                if hasattr(operation_args, attr):
+                    setattr(operation_args, attr, getattr(batch_args, attr, None))
+            exit_code = operation_args.func(operation_args) or EXIT_OK
+    except SystemExit as exc:
+        exit_code = exc.code if isinstance(exc.code, int) else EXIT_USER_ERROR
+        if not isinstance(exc.code, int):
+            error = str(exc.code)
+    except NotImplementedError as exc:
+        exit_code = EXIT_UNSUPPORTED
+        error = str(exc) or "not implemented for this backend"
+    except Exception as exc:  # noqa: BLE001
+        exit_code = EXIT_RUNTIME_ERROR
+        error = f"{type(exc).__name__}: {exc}"
+
+    stdout_value = stdout.getvalue().strip()
+    stderr_value = stderr.getvalue().strip()
+    if stdout_value:
+        try:
+            result_payload = json.loads(stdout_value)
+        except json.JSONDecodeError:
+            result_payload = stdout_value
+    fields = {"duration_ms": round((time.perf_counter() - started) * 1000)}
+    if result_payload is not None:
+        fields["result"] = result_payload
+    if stderr_value:
+        fields["stderr"] = stderr_value
+    if error:
+        fields["error"] = error
+    return _batch_result(operation, exit_code=exit_code, **fields)
+
+
+def cmd_batch(args) -> int:
+    operations = _read_batch_operations(args)
+    if not operations:
+        raise SystemExit("Batch input contained no operations.")
+    results = []
+    with _with_client(args) as client:
+        token = _BATCH_CLIENT.set(client)
+        try:
+            for operation in operations:
+                result = _execute_batch_operation(operation, args)
+                results.append(result)
+                if args.stop_on_error and not result["ok"]:
+                    break
+        finally:
+            _BATCH_CLIENT.reset(token)
+
+    failures = sum(not result["ok"] for result in results)
+    summary = {
+        "requested": len(operations),
+        "completed": len(results),
+        "failed": failures,
+        "stopped_early": len(results) < len(operations),
+    }
+    if args.json:
+        print(json.dumps({"results": results, "summary": summary}, indent=2, default=str))
+    else:
+        for result in results:
+            print(json.dumps(result, separators=(",", ":"), default=str))
+        print(json.dumps({"summary": summary}, separators=(",", ":")))
+    return EXIT_OK if failures == 0 else EXIT_USER_ERROR
 
 
 # ---------------------------------------------------------------------------
@@ -2202,6 +2417,23 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Print just the registry directory path and exit.")
     _add_output_args(p_list)
     p_list.set_defaults(func=cmd_list)
+
+    # batch
+    p_batch = sub.add_parser(
+        "batch",
+        help="Execute JSONL CLI operations through one server connection.",
+    )
+    source = p_batch.add_mutually_exclusive_group(required=True)
+    source.add_argument("--file", metavar="PATH", help="Read JSONL operations from PATH.")
+    source.add_argument("--stdin", action="store_true", help="Read JSONL operations from stdin.")
+    p_batch.add_argument(
+        "--stop-on-error",
+        action="store_true",
+        help="Stop after the first failed operation (default: continue).",
+    )
+    _add_server_filter_args(p_batch)
+    _add_output_args(p_batch)
+    p_batch.set_defaults(func=cmd_batch)
 
     # list_functions
     p_lf = sub.add_parser("list_functions", help="List functions in the binary.")

--- a/declib/skills/decompiler/SKILL.md
+++ b/declib/skills/decompiler/SKILL.md
@@ -64,6 +64,23 @@ Typical first-hour workflow on a stripped binary:
 4. `decompiler xref_to "Welcome"` → jump from a string to its users
 5. `decompiler decompile <addr>` on whichever function came out of steps 3–4
 
+When several independent reads are already known, send them as a JSONL batch
+to avoid paying Python startup, server discovery, and connection setup for
+each command:
+
+```bash
+decompiler batch --stdin --json <<'EOF'
+{"id":"functions","argv":["list_functions","--filter","main|auth"]}
+{"id":"strings","argv":["list_strings","--filter","flag|pass"]}
+{"id":"main","argv":["decompile","main"]}
+EOF
+```
+
+The batch selects one server with the usual outer `--id`, `--binary`, or
+`--backend` flags. Operations use ordinary CLI argument arrays, inherit that
+server, return an independent result/error, and continue after failures by
+default. Use `--stop-on-error` when later operations depend on earlier ones.
+
 ## Core workflow
 
 ```bash
@@ -134,6 +151,7 @@ same binary.
 |---|---|---|
 | `load <bin>` | Start a server on the binary. Idempotent: returns existing unless `--force`/`--replace`. | `--backend`, `--id`, `--force`, `--replace`, `--project-dir`, `--json` |
 | `list` | Show all running servers and the registry path. | `--show-registry`, `--json` |
+| `batch` | Run JSONL operations over one persistent server connection. | `--file`/`--stdin`, `--stop-on-error`, server selector, `--json` |
 | `stop` | Shut down one or all servers. `--save` flushes analysis to disk first; `--discard` drops unsaved edits. | `--id`, `--binary`, `--all`, `--save`, `--discard`, `--json` |
 | `save` | Persist backend analysis to disk so renames/types/comments survive a reload. | `--path`, `--id`, `--binary`, `--backend`, `--json` |
 | `list_functions` | Enumerate every function (ADDR, SIZE, NAME). | `--filter REGEX`, `--json` |

--- a/docs/decompiler_cli.md
+++ b/docs/decompiler_cli.md
@@ -187,6 +187,39 @@ ID           BACKEND  PID      BINARY
   scripting manual cleanup).
 - **`--json`** emits `{"registry_dir": "...", "servers": [...]}`.
 
+### `batch`
+
+Execute several structured CLI operations over one persistent server
+connection. This avoids a new Python process, registry lookup, and socket
+handshake for every operation.
+
+```bash
+decompiler batch --file operations.jsonl [--id ID | --binary PATH | --backend BACKEND] [--stop-on-error] [--json]
+decompiler batch --stdin [--id ID | --binary PATH | --backend BACKEND] [--stop-on-error] [--json]
+```
+
+The input is JSON Lines: one object with a unique optional `id` and a CLI
+argument array per line.
+
+```jsonl
+{"id":"functions","argv":["list_functions","--filter","main|auth"]}
+{"id":"main","argv":["decompile","main"]}
+{"id":"header","argv":["read_memory","0","4","--format","hex"]}
+```
+
+Choose the server on the outer `batch` command. Operations inherit that
+target and must not contain their own `--id`, `--binary`, or `--backend`.
+Server lifecycle commands (`load`, `list`, `stop`, `sync`, and nested
+`batch`) and unstructured `--raw` output are rejected inside a batch; normal
+inspection and mutation commands, including `save`, are supported.
+
+By default, output is compact JSONL: one result per completed operation and a
+final summary line. `--json` emits one pretty JSON envelope with `results`
+and `summary`. Each result includes the operation ID, command, exit status,
+duration, and parsed JSON result or error. Processing continues after an
+error unless `--stop-on-error` is set, and the batch exits nonzero if any
+completed operation failed.
+
 ### `stop`
 
 Stop one or all servers.

--- a/tests/test_decompiler_cli.py
+++ b/tests/test_decompiler_cli.py
@@ -267,6 +267,35 @@ class _CLIBackendTestBase(unittest.TestCase):
                 [f"0x{addr:x}" for addr in entry["addrs"]],
             )
 
+    def test_batch_mixed_reads(self):
+        """A real server executes mixed commands through one batch request."""
+        self._load_fauxware()
+        name = self._resolve_main_name()
+        operations = [
+            {"id": "functions", "argv": ["list_functions", "--filter", "auth"]},
+            {"id": "decompile", "argv": ["decompile", name]},
+            {"id": "header", "argv": ["read_memory", "0", "4", "--format", "hex"]},
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch_path = Path(tmpdir) / "operations.jsonl"
+            batch_path.write_text(
+                "\n".join(json.dumps(operation) for operation in operations),
+                encoding="utf-8",
+            )
+            result = _run_cli("batch", "--file", str(batch_path), "--json")
+
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["summary"], {
+            "requested": 3,
+            "completed": 3,
+            "failed": 0,
+            "stopped_early": False,
+        })
+        results = {entry["id"]: entry for entry in payload["results"]}
+        self.assertTrue(results["functions"]["result"])
+        self.assertTrue(results["decompile"]["result"]["text"])
+        self.assertEqual(results["header"]["result"]["hex"], "7f454c46")
+
     def test_list_strings(self):
         self._load_fauxware()
         # Every supported backend sees this string in fauxware.
@@ -1465,6 +1494,101 @@ class TestArtifactWireSerialization(unittest.TestCase):
         encoded = dec.dumps(fmt=ArtifactFormat.TOML)
         with self.assertRaises(toml.decoder.TomlDecodeError):
             Decompilation.loads(encoded, fmt=ArtifactFormat.TOML)
+
+
+class TestCLIBatch(unittest.TestCase):
+    def _run_batch(self, operations, *extra_args):
+        from declib.artifacts import Decompilation
+        from declib.cli import decompiler_cli
+
+        client = mock.MagicMock()
+        client.__enter__.return_value = client
+        client.functions = {0x1000: SimpleNamespace(name="main", size=32)}
+        client.decompile.return_value = Decompilation(
+            addr=0x1000,
+            text="int main(void) { return 0; }",
+            decompiler="test",
+        )
+        client.read_memory.return_value = b"\x7fELF"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            batch_path = Path(tmpdir) / "operations.jsonl"
+            batch_path.write_text(
+                "\n".join(
+                    value if isinstance(value, str) else json.dumps(value)
+                    for value in operations
+                )
+            )
+            args = decompiler_cli.build_parser().parse_args(
+                ["batch", "--file", str(batch_path), "--json", *extra_args]
+            )
+            stdout = StringIO()
+            with mock.patch.object(
+                decompiler_cli, "_select_server", return_value={"socket_path": "/tmp/test.sock"}
+            ) as select_server:
+                with mock.patch.object(
+                    decompiler_cli, "_connect_client", return_value=client
+                ) as connect_client:
+                    with redirect_stdout(stdout):
+                        exit_code = decompiler_cli.cmd_batch(args)
+
+        return (
+            exit_code,
+            json.loads(stdout.getvalue()),
+            client,
+            select_server,
+            connect_client,
+        )
+
+    def test_mixed_operations_share_one_client(self):
+        exit_code, payload, client, select_server, connect_client = self._run_batch(
+            [
+                {"id": "functions", "argv": ["list_functions", "--filter", "main"]},
+                {"id": "decompile", "argv": ["decompile", "main"]},
+                {"id": "header", "argv": ["read_memory", "0x1000", "4"]},
+            ]
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["summary"]["completed"], 3)
+        self.assertEqual(payload["summary"]["failed"], 0)
+        self.assertTrue(all(result["ok"] for result in payload["results"]))
+        self.assertEqual(payload["results"][0]["result"][0]["name"], "main")
+        self.assertEqual(payload["results"][1]["result"]["text"], client.decompile.return_value.text)
+        self.assertEqual(payload["results"][2]["result"]["hex"], "7f454c46")
+        select_server.assert_called_once()
+        connect_client.assert_called_once()
+        client.decompile.assert_called_once_with(0x1000, map_lines=False)
+
+    def test_stop_on_error_and_input_errors(self):
+        exit_code, payload, _client, _select, _connect = self._run_batch(
+            [
+                "not json",
+                {"id": "never-runs", "argv": ["list_functions"]},
+            ],
+            "--stop-on-error",
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["summary"]["requested"], 2)
+        self.assertEqual(payload["summary"]["completed"], 1)
+        self.assertTrue(payload["summary"]["stopped_early"])
+        self.assertIn("Invalid JSON", payload["results"][0]["error"])
+
+    def test_lifecycle_and_raw_operations_are_rejected(self):
+        exit_code, payload, _client, _select, _connect = self._run_batch(
+            [
+                {"id": "stop", "argv": ["stop", "--all"]},
+                {"id": "raw", "argv": ["decompile", "main", "--raw"]},
+                {"id": "bypass", "argv": ["-v", "stop", "--all"]},
+            ]
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(payload["summary"]["failed"], 3)
+        self.assertIn("not allowed", payload["results"][0]["error"])
+        self.assertIn("--raw", payload["results"][1]["error"])
+        self.assertIn("not allowed", payload["results"][2]["error"])
 
 
 class TestCLIFormatters(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add `decompiler batch` for JSONL operations over one persistent server connection
- reuse the existing CLI parser and command implementations, while inheriting one outer server target
- return structured per-operation results, errors, exit codes, and durations with continue/stop-on-error modes
- reject lifecycle, nested-batch, per-operation server-selection, and raw-output operations
- document batching in the CLI guide and bundled agent skill

## Why

Agent traces commonly issue several independent decompiler reads in succession. Even with a persistent backend server, separate CLI calls repeatedly pay for Python startup, registry lookup, and socket setup. This command amortizes those client-side costs without adding a second command API.

In a local live-angr smoke test on a warm server, 10 mixed operations took:

- separate CLI processes: **1.59 s**
- one batch: **0.27 s**

That is about **5.9x faster** for the tested workload. All 10 batch operations succeeded.

## Input example

```jsonl
{"id":"functions","argv":["list_functions","--filter","main|auth"]}
{"id":"main","argv":["decompile","main"]}
{"id":"header","argv":["read_memory","0","4","--format","hex"]}
```

```bash
decompiler batch --file operations.jsonl --id SERVER_ID --json
```

## Tests

- `tests/test_decompiler_cli.py`: **30 passed, 217 skipped** locally (backend tests skip without the artifact corpus)
- core workflow tests: **11 passed**
- focused batch tests cover one connection for mixed operations, per-item input errors, stop-on-error, and unsafe/lifecycle-command rejection
- backend-parametrized integration test exercises mixed batch reads against each available decompiler in CI
- live angr smoke: list functions, repeated decompile/disassemble, and memory read all succeeded through one connection

The repository's decompiler workflow currently fails before pytest when `TOOLING_KEY` is unavailable to fork PRs; core workflows are unaffected and pass.
