### PR TITLE
Fix CI failures: CLI stdout log pollution and Ghidra line-map pickling

### DIFF
--- a/.github/workflows/dec-tests.yml
+++ b/.github/workflows/dec-tests.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.10

--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -84,9 +84,16 @@ _BATCH_DISALLOWED_COMMANDS = {
 def _configure_logging(verbose: bool) -> None:
     level = logging.DEBUG if verbose else logging.WARNING
     logging.basicConfig(level=level, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    declib_logger = logging.getLogger("declib")
+    # The declib package installs a console handler on sys.stdout, but the CLI
+    # reserves stdout for command payloads (JSON/text) — a stray log line there
+    # breaks `--json` consumers. Push all log chatter to stderr.
+    for handler in declib_logger.handlers:
+        if isinstance(handler, logging.StreamHandler) and getattr(handler, "stream", None) is sys.stdout:
+            handler.setStream(sys.stderr)
     # Keep declib chatter quiet unless --verbose; otherwise INFO logs clobber the CLI output.
     if not verbose:
-        logging.getLogger("declib").setLevel(logging.WARNING)
+        declib_logger.setLevel(logging.WARNING)
 
 
 def _parse_target(target: str) -> Tuple[Optional[int], Optional[str]]:

--- a/declib/decompilers/ghidra/interface.py
+++ b/declib/decompilers/ghidra/interface.py
@@ -274,16 +274,19 @@ class GhidraDecompilerInterface(DecompilerInterface):
             linenum_to_addr[1].add(function.addr)
             pp = PrettyPrinter(g_func, dec_results.getCCodeMarkup(), None)
             for line in pp.getLines():
-                ln = line.getLineNumber()
+                # Coerce jpype Java numbers to plain ints — the Decompilation is
+                # pickled across the server/client boundary, and Java objects
+                # cannot be unpickled in the JVM-less client process.
+                ln = int(line.getLineNumber())
                 for i in range(line.getNumTokens()):
                     min_addr = line.getToken(i).getMinAddress()
                     if min_addr is None:
                         continue
 
-                    linenum_to_addr[ln].add(min_addr.offset)
+                    linenum_to_addr[ln].add(int(min_addr.offset))
                     max_addr = line.getToken(i).getMaxAddress()
                     if max_addr is not None:
-                        linenum_to_addr[ln].add(max_addr.offset)
+                        linenum_to_addr[ln].add(int(max_addr.offset))
 
             decompilation.line_map = {
                 k: list(v) for k, v in dict(linenum_to_addr).items()


### PR DESCRIPTION
## Summary

The two consistently failing tests in [run 29939071220](https://github.com/binsync/declib/actions/runs/29939071220/job/88988044793) were real bugs, not flaky tests, so both are kept and fixed:

- **`TestDecompilerCLIAngr::test_stop`** — the declib package logger's console handler writes to **stdout** (`declib/logger.py`). During `decompiler stop`, the expected server-shutdown race logs `ERROR ... Request failed: Failed to receive message length` onto stdout ahead of the CLI's JSON payload, breaking `json.loads`. The CLI now retargets declib console log handlers to stderr in `_configure_logging`, so stdout stays reserved for command payloads.
- **`TestDecompilerCLIGhidra::test_decompile_line_map`** — the Ghidra line map was built from jpype Java numbers (`JInt` line numbers, `JLong` address offsets from `getMinAddress().offset`). Those got pickled into the server's response, and the JVM-less client process failed to unpickle them with `jpype._core.JVMNotRunning: Java Virtual Machine is not running`, exiting 1. Reproduced locally and fixed by coercing to plain Python ints before building `line_map`.

Also raises the workflow `timeout-minutes` from 15 to 20 so full runs aren't killed.

## Test plan
- [x] Reproduced the Ghidra `--map-lines` failure locally, verified fixed end-to-end via the real CLI (14 line-map entries returned, exit 0)
- [x] Verified declib ERROR logs now land on stderr, not stdout
- [x] `pytest tests/test_decompiler_cli.py::TestDecompilerCLIAngr` — 50 passed, 12 skipped
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FPzCH8ehxeXpsFkqsCSU1