### PR TITLE
Accept every supported backend in `backend status`, not just jadx

### DIFF
--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -68,7 +68,14 @@ EXIT_RUNTIME_ERROR = 1     # unhandled/unknown failure
 EXIT_UNSUPPORTED = 2       # feature not implemented for the selected backend
 
 from declib.api import server_registry
-from declib.decompilers import SUPPORTED_DECOMPILERS
+from declib.decompilers import (
+    SUPPORTED_DECOMPILERS,
+    ANGR_DECOMPILER,
+    BINJA_DECOMPILER,
+    GHIDRA_DECOMPILER,
+    IDA_DECOMPILER,
+    JADX_DECOMPILER,
+)
 from declib import skills
 
 _l = logging.getLogger("declib.cli.decompiler")
@@ -2272,16 +2279,60 @@ def cmd_install_skill(args) -> int:
 # optional backend runtimes
 # ---------------------------------------------------------------------------
 
+def _probe_import(module: str) -> Tuple[bool, Optional[str]]:
+    """Return (importable, error_text) for a backend's Python entry point."""
+    import importlib
+
+    try:
+        importlib.import_module(module)
+        return True, None
+    except Exception as exc:  # noqa: BLE001 - a bad license raises, not just ImportError
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def _native_backend_status(name: str) -> Dict:
+    """Report whether a native (non-JADX) backend runtime is importable.
+
+    Mirrors the shape of ``JadxWorkerClient.runtime_status()``: an
+    ``available`` flag plus human-readable ``reasons`` when it is not, so
+    every backend answers ``backend status`` the same way.
+    """
+    # Ordered candidates: the first importable one wins. IDA exposes a
+    # different module per major version, so several are acceptable.
+    candidates = {
+        IDA_DECOMPILER: ["idapro", "idaapi", "ida"],
+        GHIDRA_DECOMPILER: ["pyghidra"],
+        BINJA_DECOMPILER: ["binaryninja"],
+        ANGR_DECOMPILER: ["angr"],
+    }[name]
+
+    reasons = []
+    for module in candidates:
+        ok, err = _probe_import(module)
+        if ok:
+            status = {"available": True, "backend": name, "module": module}
+            if name == GHIDRA_DECOMPILER:
+                status["ghidra_install_dir"] = os.getenv("GHIDRA_INSTALL_DIR")
+            return status
+        reasons.append(f"{module}: {err}")
+
+    status = {"available": False, "backend": name, "reasons": reasons}
+    if name == GHIDRA_DECOMPILER and not os.getenv("GHIDRA_INSTALL_DIR"):
+        status["reasons"].append("GHIDRA_INSTALL_DIR is not set")
+    return status
+
+
 def cmd_backend(args) -> int:
     if args.backend_action != "status":
         raise SystemExit(f"Unknown backend action: {args.backend_action}")
-    if args.name == "jadx":
+    if args.name == JADX_DECOMPILER:
         from declib.decompilers.jadx.worker_client import JadxWorkerClient
 
         status = JadxWorkerClient.runtime_status()
-        _emit(args, status)
-        return EXIT_OK if status["available"] else EXIT_NOT_FOUND
-    raise SystemExit(f"Backend runtime status is not implemented for {args.name!r}")
+    else:
+        status = _native_backend_status(args.name)
+    _emit(args, status)
+    return EXIT_OK if status["available"] else EXIT_NOT_FOUND
 
 
 # ---------------------------------------------------------------------------
@@ -2572,7 +2623,7 @@ def build_parser() -> argparse.ArgumentParser:
         "status",
         help="Check whether an optional backend runtime is ready.",
     )
-    p_backend_status.add_argument("name", choices=["jadx"])
+    p_backend_status.add_argument("name", choices=sorted(SUPPORTED_DECOMPILERS))
     _add_output_args(p_backend_status)
     p_backend_status.set_defaults(func=cmd_backend)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -87,3 +87,30 @@ class TestInstaller(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(argv=sys.argv)
+
+
+class TestBackendStatus(unittest.TestCase):
+    """`decompiler backend status` must answer for every supported backend.
+
+    Previously only `jadx` was accepted, so an agent that suspected the IDA
+    backend was unhealthy had no way to query it.
+    """
+
+    def test_every_supported_backend_is_accepted(self):
+        from declib.cli.decompiler_cli import build_parser
+        from declib.decompilers import SUPPORTED_DECOMPILERS
+
+        parser = build_parser()
+        for name in sorted(SUPPORTED_DECOMPILERS):
+            args = parser.parse_args(["backend", "status", name])
+            assert args.name == name
+
+    def test_native_status_reports_reasons_when_unavailable(self):
+        from declib.cli.decompiler_cli import _native_backend_status
+
+        status = _native_backend_status("binja")
+        assert "available" in status
+        assert status["backend"] == "binja"
+        if not status["available"]:
+            # An unavailable backend must explain itself, not just say "no".
+            assert status["reasons"]


### PR DESCRIPTION
### Problem

`decompiler backend status` hardcodes `choices=["jadx"]`, so every other backend is rejected at argparse:

```
$ decompiler backend status ida
usage: decompiler backend status [-h] [--json] {jadx}
decompiler backend status: error: argument name: invalid choice: 'ida' (choose from 'jadx')
```

This blocks self-diagnosis. An agent (or human) who suspects the IDA backend is unhealthy has no way to ask.

We hit this during D3CTF 2026, running DecLib as the sole decompiler interface for a fleet of autonomous CTF agents. Replaying the session transcripts, the pattern was consistent: agents that hit a decompiler-server failure and then could not check backend health stopped using the CLI and hand-wrote headless IDAPython instead. In 6 of 6 sessions where both occurred, the first raw-IDA invocation came strictly *after* the first DecLib failure. The one RE session whose first failure came late never reached for IDA at all.

Being unable to answer "is the backend actually up?" turns a transient failure into an abandoned tool.

### Change

- `backend status` now accepts every name in `SUPPORTED_DECOMPILERS`.
- New `_native_backend_status()` probes each native backend's Python entry point and returns the same shape JADX already does: an `available` flag, plus human-readable `reasons` when it is not available.
- IDA is probed across its per-major-version modules (`idapro` / `idaapi` / `ida`).
- Ghidra additionally reports `GHIDRA_INSTALL_DIR`, and calls it out when unset.
- Exit code follows the existing convention — `EXIT_OK` when available, `EXIT_NOT_FOUND` when not.

The `jadx` path is untouched.

### Verification

Run in a container carrying real IDA, Ghidra, angr and JADX (no Binary Ninja license, which is why `binja` is the negative case):

| backend | `available` | detail | rc |
|---|---|---|---|
| ida | true | `module: idapro` | 0 |
| ghidra | true | `module: pyghidra`, `ghidra_install_dir: /opt/ghidra` | 0 |
| angr | true | `module: angr` | 0 |
| binja | false | `reasons: ["binaryninja: ModuleNotFoundError: ..."]` | 1 |
| jadx | true | unchanged output | 0 |

Two tests added to `tests/test_cli.py`: every supported backend parses, and an unavailable backend must explain itself rather than just reporting `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)