### PR TITLE
Propagate server-side error text instead of dropping it

### DIFF
--- a/declib/api/decompiler_client.py
+++ b/declib/api/decompiler_client.py
@@ -428,8 +428,21 @@ class DecompilerClient:
                 # Check if response is an error
                 if isinstance(response, dict) and "error" in response:
                     error_type = response.get("type", "Exception")
-                    error_msg = response.get("error", "Unknown error")
-                    
+                    error_msg = response.get("error", "") or ""
+
+                    # An exception raised without arguments serializes to an
+                    # empty string, which would surface to the caller as a
+                    # blank error. Fall back to the server-side traceback, or
+                    # at minimum name the exception type.
+                    # The reconstructed exception already carries the type, so
+                    # the fallback text does not repeat it.
+                    if not error_msg.strip():
+                        server_tb = (response.get("traceback") or "").strip()
+                        if server_tb:
+                            error_msg = f"(no message); server traceback:\n{server_tb}"
+                        else:
+                            error_msg = "(no message)"
+
                     # Try to reconstruct the original exception type
                     if error_type == "KeyError":
                         raise KeyError(error_msg)
@@ -465,7 +478,11 @@ class DecompilerClient:
                 
                 return response
             except Exception as e:
-                _l.error(f"Request failed: {e} for {request}")
+                # Always name the exception type: str(e) is empty for
+                # exceptions raised without arguments (a reset connection,
+                # for instance), which used to log "Request failed:  for ...".
+                detail = str(e) or "<no message>"
+                _l.error(f"Request failed: {type(e).__name__}: {detail} for {request}")
                 raise
     
     # Properties - mirror DecompilerInterface properties

--- a/declib/api/decompiler_server.py
+++ b/declib/api/decompiler_server.py
@@ -10,6 +10,7 @@ import struct
 import threading
 import time
 import tempfile
+import traceback
 import os
 from typing import Optional, Dict, Any, List
 
@@ -129,8 +130,15 @@ class SocketServerHandler:
                     # Client disconnected
                     break
                 except Exception as e:
-                    # Send error response
-                    error_response = {"error": str(e), "type": type(e).__name__}
+                    # Send error response. str(e) is empty for exceptions
+                    # raised without arguments, which would otherwise reach
+                    # the client as a blank message, so carry the traceback
+                    # too and let the client fall back to it.
+                    error_response = {
+                        "error": str(e),
+                        "type": type(e).__name__,
+                        "traceback": traceback.format_exc(),
+                    }
                     try:
                         SocketProtocol.send_message(client_socket, error_response)
                     except:

--- a/tests/test_client_errors.py
+++ b/tests/test_client_errors.py
@@ -1,0 +1,74 @@
+"""Server-side error text must survive the trip back to the client.
+
+Regression test for a blank error observed in the wild:
+
+    Request failed:  for {'type': 'method_call',
+                          'method_name': 'get_func_containing', ...}
+
+Note the empty text after "failed:" -- the real cause was dropped.
+"""
+import logging
+import unittest
+from unittest.mock import patch
+
+from declib.api.decompiler_client import DecompilerClient
+
+
+class _FakeSocket:
+    pass
+
+
+def _client_with_response(response):
+    """Build a client that does no I/O and yields one canned response."""
+    client = DecompilerClient.__new__(DecompilerClient)
+    client._socket = _FakeSocket()
+    client._socket_lock = __import__("threading").Lock()
+    with patch("declib.api.decompiler_client.SocketProtocol") as proto:
+        proto.send_message.return_value = None
+        proto.recv_message.return_value = response
+        return client
+
+
+class TestErrorPropagation(unittest.TestCase):
+    def _send(self, response):
+        client = _client_with_response(response)
+        with patch("declib.api.decompiler_client.SocketProtocol") as proto:
+            proto.send_message.return_value = None
+            proto.recv_message.return_value = response
+            return client._send_request({"type": "method_call",
+                                         "method_name": "get_func_containing"})
+
+    def test_empty_error_falls_back_to_traceback(self):
+        """An exception with no message must not surface as blank."""
+        with self.assertRaises(RuntimeError) as ctx:
+            self._send({
+                "error": "",
+                "type": "ConnectionResetError",
+                "traceback": "Traceback (most recent call last):\n  RealCause: boom",
+            })
+        text = str(ctx.exception)
+        assert "ConnectionResetError" in text
+        assert "RealCause: boom" in text
+
+    def test_empty_error_without_traceback_still_names_the_type(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self._send({"error": "", "type": "IndexError"})
+        assert "IndexError" in str(ctx.exception)
+
+    def test_normal_error_text_is_unchanged(self):
+        with self.assertRaises(ValueError) as ctx:
+            self._send({"error": "bad address 0x41", "type": "ValueError"})
+        assert str(ctx.exception) == "bad address 0x41"
+
+    def test_log_line_names_the_exception_type(self):
+        """The log must never read 'Request failed:  for ...'."""
+        with self.assertLogs("declib.api.decompiler_client", level=logging.ERROR) as logs:
+            with self.assertRaises(RuntimeError):
+                self._send({"error": "", "type": "ConnectionResetError"})
+        joined = "\n".join(logs.output)
+        assert "Request failed:  for" not in joined
+        assert "ConnectionResetError" in joined
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem

From a real solve session, logged by `DecompilerClient`:

```
Request failed:  for {'type': 'method_call', 'method_name': 'get_func_containing', 'args': [5368960019]}
```

Note the empty text after `failed:`. The address was well-formed (`0x14003D413`, an ordinary Windows image-base-`0x140000000` offset), so this was not a malformed input — the caller was simply handed a failure with no cause attached.

### Root cause

`DecompilerServer` serializes errors as:

```python
error_response = {"error": str(e), "type": type(e).__name__}
```

`str(e)` is the **empty string** for any exception raised without arguments — a reset connection, a bare `IndexError` out of a backend binding, and so on. `DecompilerClient` then reconstructed that empty string as the message and logged it verbatim, so both the raised exception and the log line lost the cause.

### Change

- **Server** attaches `traceback.format_exc()` to the error response, so the real cause survives even when `str(e)` is empty.
- **Client** falls back to that traceback when the message is blank, and otherwise at least names the exception type. Non-empty messages pass through byte-for-byte, and the existing exception-type reconstruction (`KeyError` / `ValueError` / `AttributeError` / `NotImplementedError`) is unchanged.
- **Client log** always names the exception type, so it can no longer read `Request failed:  for ...`.

### Tests

`tests/test_client_errors.py` covers four paths:

| case | expectation |
|---|---|
| empty message + server traceback | traceback text reaches the caller |
| empty message, no traceback | exception type still named |
| normal message | passed through unchanged |
| log line | asserts `"Request failed:  for"` can never appear again |

All 4 pass.

### Note on the existing suite

`tests/test_client_server.py` reports 16 errors **both with and without** this change — it needs fixtures under `/bs-artifacts/binaries/` that are absent from the test image (`java.io.IOException: File not found: file:///bs-artifacts/binaries/fauxware`). Pre-existing and untouched here; flagging it in case those fixtures should be vendored or the tests skipped when missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)