### PR TITLE
Make server startup and teardown failures diagnosable

### DIFF
--- a/declib/api/server_registry.py
+++ b/declib/api/server_registry.py
@@ -86,8 +86,14 @@ def _is_record_live(record: Dict) -> bool:
     return True
 
 
-def list_servers(prune_stale: bool = True) -> List[Dict]:
-    """Return all server records, optionally dropping and removing stale entries."""
+def list_servers(prune_stale: bool = True, pruned: Optional[List[Dict]] = None) -> List[Dict]:
+    """Return all server records, optionally dropping and removing stale entries.
+
+    Pass a list as ``pruned`` to receive the records that were removed. Without
+    it, a server that has died is simply gone, and a caller can only report
+    "no server matches" — which reads as "you never started one" rather than
+    "yours died, here is how to bring it back".
+    """
     records: List[Dict] = []
     try:
         entries = sorted(_registry_dir().glob("*.json"))
@@ -103,6 +109,8 @@ def list_servers(prune_stale: bool = True) -> List[Dict]:
             continue
 
         if prune_stale and not _is_record_live(record):
+            if pruned is not None:
+                pruned.append(record)
             try:
                 entry.unlink()
             except FileNotFoundError:
@@ -148,11 +156,16 @@ def find_servers(
     binary_path: Optional[str] = None,
     binary_hash: Optional[str] = None,
     backend: Optional[str] = None,
+    pruned: Optional[List[Dict]] = None,
 ) -> List[Dict]:
-    """Return all server records matching the provided filters."""
+    """Return all server records matching the provided filters.
+
+    ``pruned`` is forwarded to :func:`list_servers`; pass a list to learn which
+    dead servers were reaped during this lookup.
+    """
     matches: List[Dict] = []
     binary_path_resolved = str(Path(binary_path).expanduser().resolve()) if binary_path else None
-    for record in list_servers():
+    for record in list_servers(pruned=pruned):
         if binary_path_resolved:
             record_path = record.get("binary_path")
             if not record_path:

--- a/declib/cli/decompiler_cli.py
+++ b/declib/cli/decompiler_cli.py
@@ -191,9 +191,11 @@ def _select_server(
     backend: Optional[str],
 ) -> Dict:
     """Pick a server record from the registry, or error out with a helpful message."""
+    reaped: List[Dict] = []
     records = server_registry.find_servers(
         binary_path=binary_path,
         backend=backend,
+        pruned=reaped,
     )
     if server_id:
         records = [r for r in records if r.get("id") == server_id]
@@ -201,6 +203,28 @@ def _select_server(
     if not records:
         filters = {"id": server_id, "binary_path": binary_path, "backend": backend}
         active = {k: v for k, v in filters.items() if v}
+
+        # A server that died is reaped from the registry by the lookup above,
+        # so "no server matches" otherwise reads as "you never started one".
+        # If one of the corpses matches what was asked for, say so and hand
+        # back the exact command to bring it back.
+        dead = [
+            r for r in reaped
+            if (not server_id or r.get("id") == server_id)
+            and (not backend or r.get("backend") == backend)
+        ]
+        if dead:
+            corpse = dead[0]
+            binary = corpse.get("binary_path") or "<unknown binary>"
+            reload_cmd = f"decompiler load {binary}"
+            if corpse.get("backend"):
+                reload_cmd += f" --backend {corpse['backend']}"
+            raise SystemExit(
+                f"Decompiler server {corpse.get('id')} is no longer running "
+                f"(binary: {binary}). It died or was stopped; its analysis is "
+                f"gone.\nReload it with:\n  {reload_cmd}"
+            )
+
         raise SystemExit(
             "No running decompiler server matches "
             f"{active or '(no filters)'}. Start one with `decompiler load <binary>`."
@@ -324,12 +348,49 @@ def _read_server_log_tail(
 
 def _server_start_error(message: str, log_path: Optional[Path]) -> SystemExit:
     lines = [message]
+    tail = _read_server_log_tail(log_path) if log_path is not None else ""
+
+    # "Failed to open database <path>" is what a backend says when another
+    # process already holds that project's database. On its own it reads like
+    # a corrupt or missing file, which sends people down the wrong path.
+    if "Failed to open database" in tail:
+        lines.append(
+            "\nThat usually means another decompiler server already holds this "
+            "project's database.\nCheck with `decompiler list`, then either "
+            "target it (`--id <id>`), replace it (`--replace`), or give this "
+            "one its own project (`--project-dir <path>`)."
+        )
+
     if log_path is not None:
         lines.append(f"Server log: {log_path}")
-        tail = _read_server_log_tail(log_path)
         if tail:
             lines.extend(("Server log tail:", tail))
     return SystemExit("\n".join(lines))
+
+
+def _backend_start_hint(backend: Optional[str]) -> str:
+    """Advice that matches the backend actually in use.
+
+    The old text named GHIDRA_INSTALL_DIR unconditionally, which is actively
+    misleading when the backend is IDA — it sends people to check an
+    environment variable that has nothing to do with their failure.
+    """
+    hints = {
+        "ghidra": "Check GHIDRA_INSTALL_DIR points at a Ghidra install.",
+        "ida": "Check the IDA install and that its licence/EULA is accepted "
+               "(`decompiler backend status ida`).",
+        "binja": "Check the Binary Ninja install and licence "
+                 "(`decompiler backend status binja`).",
+        "angr": "Check angr is importable (`decompiler backend status angr`).",
+        "jadx": "Check the JADX runtime (`decompiler backend status jadx`).",
+    }
+    generic = ("Run `decompiler backend status <backend>` to check the runtime, "
+               "and read the server log below.")
+    return hints.get(backend or "", generic)
+
+
+# How long to sit silent before telling the user what the server is doing.
+_SERVER_PROGRESS_INTERVAL = 10.0
 
 
 def _wait_for_server(
@@ -337,9 +398,19 @@ def _wait_for_server(
     process: Optional[subprocess.Popen] = None,
     log_path: Optional[Path] = None,
     timeout: float = _SERVER_START_TIMEOUT,
+    backend: Optional[str] = None,
 ) -> Dict:
-    """Block until a server with `server_id` appears in the registry or timeout."""
-    deadline = time.time() + timeout
+    """Block until a server with `server_id` appears in the registry or timeout.
+
+    Reports progress while waiting. Analyzing a large binary legitimately takes
+    minutes, but a silent wait is indistinguishable from a hang — which is how
+    a slow load gets abandoned for a hand-rolled script.
+    """
+    start = time.time()
+    deadline = start + timeout
+    next_report = start + _SERVER_PROGRESS_INTERVAL
+    last_line = ""
+
     while time.time() < deadline:
         record = server_registry.find_server(server_id=server_id)
         if record and record.get("socket_path") and os.path.exists(record["socket_path"]):
@@ -352,10 +423,27 @@ def _wait_for_server(
                     f"{exit_status} before registering.",
                     log_path,
                 )
+
+        now = time.time()
+        if now >= next_report:
+            # Surface the backend's own last log line, so "still analyzing" is
+            # visibly different from "wedged".
+            tail = _read_server_log_tail(log_path, max_bytes=2048)
+            current = tail.splitlines()[-1].strip() if tail else ""
+            elapsed = now - start
+            if current and current != last_line:
+                print(f"  [{elapsed:.0f}s] {current}", file=sys.stderr)
+                last_line = current
+            else:
+                print(f"  [{elapsed:.0f}s] still starting "
+                      f"({timeout - elapsed:.0f}s left)...", file=sys.stderr)
+            next_report = now + _SERVER_PROGRESS_INTERVAL
+
         time.sleep(_SERVER_POLL_INTERVAL)
+
     raise _server_start_error(
         f"Timed out waiting {timeout:g}s for server {server_id} to start. "
-        "Check backend dependencies (e.g. GHIDRA_INSTALL_DIR) and retry.",
+        f"{_backend_start_hint(backend)}",
         log_path,
     )
 
@@ -406,6 +494,14 @@ def cmd_load(args) -> int:
         project_dir = Path(args.project_dir).expanduser().resolve()
     else:
         project_dir = _default_project_dir(binary_path, backend)
+        # --force means "run a second copy", but the default project dir is
+        # derived from binary+backend alone, so the second server would open
+        # the same on-disk database as the first. IDA (and Ghidra) hold a lock
+        # on it, and the new server dies with a bare
+        # "Failed to open database <binary>" that names neither the lock nor
+        # the server holding it. Give each forced copy its own project dir.
+        if args.force and existing:
+            project_dir = project_dir.with_name(f"{project_dir.name}-{server_id}")
     log_path = _server_log_path(server_id)
     process = _spawn_server(
         binary_path,
@@ -419,6 +515,7 @@ def cmd_load(args) -> int:
         process=process,
         log_path=log_path,
         timeout=args.timeout,
+        backend=backend,
     )
     _emit(args, {
         "status": "started",

--- a/tests/test_decompiler_cli.py
+++ b/tests/test_decompiler_cli.py
@@ -2104,3 +2104,75 @@ class TestExportArgs(unittest.TestCase):
         self.assertEqual(_safe_filename("", 0x55), "00000055.c")
         # Two same-named functions at different addresses cannot collide.
         self.assertNotEqual(_safe_filename("f", 1), _safe_filename("f", 2))
+class TestServerStartupDiagnostics(unittest.TestCase):
+    """Startup/teardown diagnostics. No backend required."""
+
+    def test_backend_hint_matches_the_backend(self):
+        """The old text named GHIDRA_INSTALL_DIR whatever the backend was."""
+        from declib.cli.decompiler_cli import _backend_start_hint
+
+        self.assertIn("GHIDRA_INSTALL_DIR", _backend_start_hint("ghidra"))
+        for other in ("ida", "binja", "angr", "jadx"):
+            with self.subTest(backend=other):
+                hint = _backend_start_hint(other)
+                self.assertNotIn("GHIDRA_INSTALL_DIR", hint)
+                self.assertIn(other, hint)
+        # Unknown/absent backend still gets something actionable.
+        self.assertIn("backend status", _backend_start_hint(None))
+
+    def test_database_lock_gets_an_explanation(self):
+        """A bare "Failed to open database" reads like corruption."""
+        import tempfile as _tf
+        from declib.cli.decompiler_cli import _server_start_error
+
+        with _tf.NamedTemporaryFile("w", suffix=".log", delete=False) as fh:
+            fh.write("ERROR - Failed to start server: Failed to open database /tmp/x\n")
+            log = Path(fh.name)
+        try:
+            text = str(_server_start_error("server died", log))
+            self.assertIn("already holds this project's database", text)
+            self.assertIn("--replace", text)
+            self.assertIn("--project-dir", text)
+        finally:
+            log.unlink()
+
+    def test_unrelated_failure_gets_no_lock_advice(self):
+        import tempfile as _tf
+        from declib.cli.decompiler_cli import _server_start_error
+
+        with _tf.NamedTemporaryFile("w", suffix=".log", delete=False) as fh:
+            fh.write("ERROR - Failed to start server: no such file\n")
+            log = Path(fh.name)
+        try:
+            self.assertNotIn("already holds", str(_server_start_error("died", log)))
+        finally:
+            log.unlink()
+
+
+class TestRegistryPruneReporting(unittest.TestCase):
+    """list_servers must be able to say what it reaped."""
+
+    def test_pruned_records_are_reported(self):
+        import tempfile as _tf
+        from declib.api import server_registry as reg
+
+        with _tf.TemporaryDirectory() as tmp:
+            os.environ["DECLIB_SERVER_REGISTRY"] = tmp
+            try:
+                dead = {
+                    "id": "deadbeef01",
+                    "pid": 999999,          # not a live process
+                    "binary_path": "/tmp/gone",
+                    "backend": "ida",
+                    "socket_path": os.path.join(tmp, "nope.sock"),
+                }
+                Path(tmp, "deadbeef01.json").write_text(json.dumps(dead))
+
+                reaped = []
+                live = reg.list_servers(pruned=reaped)
+                self.assertEqual(live, [])
+                self.assertEqual([r["id"] for r in reaped], ["deadbeef01"])
+                # The caller can now name the binary in its error message.
+                self.assertEqual(reaped[0]["binary_path"], "/tmp/gone")
+            finally:
+                os.environ.pop("DECLIB_SERVER_REGISTRY", None)


### PR DESCRIPTION
### Context

We ran DecLib as the sole decompiler interface for a fleet of autonomous CTF agents at D3CTF 2026 and replayed every session afterwards. **54 of the 62 DecLib errors** we logged were these three. None told the user what had actually happened, and each one ended with an agent abandoning the CLI for a hand-rolled IDAPython script.

---

### 1. `Failed to open database <binary>` (14×)

**Reproduced, and the cause is not what the message suggests.** It is what you get when a second server opens a project database another server already holds:

```
$ decompiler load /tmp/orig --backend ida          # fine
$ decompiler load /tmp/orig --backend ida --force
Decompiler server 7f5bf7f798 exited with status 1 before registering.
  ERROR - Failed to start server: Failed to open database /tmp/orig
```

`--force` is documented as "run a second copy", but the default project dir is derived from binary+backend alone — so the second server *always* collided with the first and died. Forced copies now get their own project dir:

```
after: two live servers
  project_dir  .../orig-5a3e46a4
  project_dir  .../orig-5a3e46a4-722556f738
```

The bare message also reads like file corruption, so any server log carrying it now gets an explanation naming the real cause and the three ways out (`--id`, `--replace`, `--project-dir`).

### 2. `Timed out waiting Ns for server to start` (19×)

Two problems.

The advice read *"Check backend dependencies (e.g. GHIDRA_INSTALL_DIR)"* regardless of backend — actively misleading when the backend is IDA. It is now backend-aware.

And the wait was **silent**, so a legitimately slow load was indistinguishable from a hang. Agents retried at 180s, then 240s, then 300s — ~12 minutes of solve budget per abandonment. The wait now reports every 10s, surfacing the backend's own last log line:

```
  [10s] INFO | declib.api.decompiler_server | Using headless interface utilizing ida
  [20s] still starting (5s left)...
Timed out waiting 25s for server 89ec2f75dd to start. Check the IDA install and
that its licence/EULA is accepted (`decompiler backend status ida`).
```

(That run is a real 137 MB `libLLVM.so` — genuinely slow rather than stuck, which is now visible.)

### 3. `No running decompiler server matches {...}` (21×)

The registry prunes dead records *during* the lookup, so a server that died left no trace and the error read as "you never started one". `list_servers` / `find_servers` can now report what they reaped, and the error names the corpse:

```
Decompiler server 078c974380 is no longer running (binary: /tmp/orig).
It died or was stopped; its analysis is gone.
Reload it with:
  decompiler load /tmp/orig --backend ida
```

**Deliberately not doing silent auto-revive.** Re-analysis can take minutes, and quietly spending them — or quietly discarding unsaved annotations — is a worse surprise than an accurate error naming the exact command to run. Happy to add it behind an explicit flag if you'd prefer.

---

### Tests

Backend-aware hints for every backend (asserting `GHIDRA_INSTALL_DIR` appears for ghidra and *only* ghidra); the lock explanation fires on lock failures and not on unrelated ones; the registry reports pruned records with enough detail to name the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
