### PR TITLE
Don't let a filename Ghidra dislikes kill the server

### DIFF
--- a/declib/decompilers/ghidra/compat/headless.py
+++ b/declib/decompilers/ghidra/compat/headless.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 from typing import Union, Optional, Tuple
 
@@ -54,6 +55,22 @@ def open_program(
     return flat_api, project, program
 
 
+# Ghidra validates project and program names and rejects a set of characters
+# outright. Both names are derived from the binary's file name below, so a
+# binary called `timo#3` makes the import throw
+#   java.lang.IllegalArgumentException: name contains invalid character: '#'
+# which reaches the caller only as a server that died with no usable reason.
+# Filenames are not ours to choose -- CTF and crackme corpora are full of
+# them -- so sanitize the derived *names* and leave the path on disk alone.
+_GHIDRA_NAME_UNSAFE = re.compile(r"[^A-Za-z0-9._\- ]")
+
+
+def ghidra_safe_name(name: str) -> str:
+    """Return `name` with characters Ghidra rejects replaced by underscores."""
+    safe = _GHIDRA_NAME_UNSAFE.sub("_", str(name)).strip(" .")
+    return safe or "program"
+
+
 def _setup_project(
     binary_path: Optional[Union[str, Path]] = None,
     project_location: Union[str, Path] = None,
@@ -75,7 +92,9 @@ def _setup_project(
     else:
         project_location = binary_path.parent
     if not project_name:
-        project_name = f"{binary_path.name}_ghidra"
+        project_name = f"{ghidra_safe_name(binary_path.name)}_ghidra"
+    else:
+        project_name = ghidra_safe_name(project_name)
     project_location /= project_name
 
     # Ensure the project location directory exists
@@ -101,7 +120,9 @@ def _setup_project(
         # XXX: binsync patch added here:
         if binary_path is not None or program_name is not None:
             if program_name is None:
-                program_name = binary_path.name
+                program_name = ghidra_safe_name(binary_path.name)
+            else:
+                program_name = ghidra_safe_name(program_name)
             if project.getRootFolder().getFile(program_name):
                 program = project.openProgram("/", program_name, False)
     except (IOException, NotFoundException):

--- a/tests/test_decompiler_cli.py
+++ b/tests/test_decompiler_cli.py
@@ -2075,6 +2075,35 @@ if __name__ == "__main__":
     unittest.main()
 
 
+class TestGhidraSafeNames(unittest.TestCase):
+    """Ghidra rejects characters that filenames are perfectly free to contain.
+
+    Both the project and program names are derived from the binary's file name,
+    so a crackme called `timo#3` kills the server with
+    `IllegalArgumentException: name contains invalid character: '#'` -- and the
+    only workaround available to the analyst is renaming the file.
+    """
+
+    def test_rejected_characters_are_replaced(self):
+        from declib.decompilers.ghidra.compat.headless import ghidra_safe_name
+
+        self.assertEqual(ghidra_safe_name("timo#3"), "timo_3")
+        self.assertEqual(ghidra_safe_name("a$b&c|d"), "a_b_c_d")
+
+    def test_ordinary_names_are_untouched(self):
+        from declib.decompilers.ghidra.compat.headless import ghidra_safe_name
+
+        for name in ("crackme", "crack_me-2.bin", "some binary v1.0"):
+            self.assertEqual(ghidra_safe_name(name), name)
+
+    def test_never_returns_an_empty_name(self):
+        """Ghidra rejects an empty name too, so degenerate input needs a value."""
+        from declib.decompilers.ghidra.compat.headless import ghidra_safe_name
+
+        for name in ("###", "", "...", "   "):
+            self.assertTrue(ghidra_safe_name(name))
+
+
 class TestExportArgs(unittest.TestCase):
     """export plumbing that needs no backend."""
 


### PR DESCRIPTION
### Problem

Ghidra validates project and program names and rejects certain characters. Both names are derived from the binary's **file name**, so a crackme called `timo#3` throws from inside the import:

```
java.lang.IllegalArgumentException: name contains invalid character: '#'
```

The caller sees only:

```
Decompiler server c3b08ec63d exited with status 1 before registering.
```

The real reason is buried in the server log, and the only workaround available to an analyst is to rename the file.

### Seen in the wild

Caught on a 40-binary benchmark run. An agent hit this, diagnosed it, and worked around it by copying `timo#3` to `timo3_working_copy` and loading that instead. It recovered — after several minutes and a backend switch.

Worth noting how it got there: it had *preferred* IDA (as SKILL.md says to), IDA crashed on this binary, it fell back to Ghidra, and then hit this. Two failures compounding.

### Change

Sanitize the derived project/program names; leave the path on disk alone. The binary is still opened by its real path — only the names handed to Ghidra change. An explicitly-passed `project_name`/`program_name` is sanitized too, since it lands in the same validator.

Verified against the binary that failed — it now loads and lists functions normally:

```
BEFORE: Failed to start server: java.lang.IllegalArgumentException: ... '#'
AFTER:  { "status": "started", ... }   →  list_functions returns 392 bytes at 0x1000
```

### Tests

Three: rejected characters are replaced; ordinary names (including spaces, dots, dashes) are untouched; degenerate input never yields an empty name, which Ghidra also rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
